### PR TITLE
Added MacOS Installation Instructions to Readme File

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ or human readable tabular formats such as:
 +-----------+----------+-------------------+--------------+---------------------+
 ```
 
+### Installation under MacOS:
+
+First install [Homebrew](https://github.com/Homebrew), a package manager for macOS, if you do not already have it installed. Open terminal and paste:
+
+```
+ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+ ```
+Add the `metrumresearchgroup/homebrew-tap` repository to the list of brew formulae:
+
+```
+brew tap metrumresearchgroup/homebrew-tap
+```
+
+Next, install babylon-cli:
+
+```
+brew install bbi
+```
+
 
 ### Development
 


### PR DESCRIPTION
Added installation instructions for MacOS to readme file so users know how to get started. 

TODO:

- [ ] Add windows, linux, etc. instructions for install to readme. 
- [ ] Merge all installation instructions and instructions for initialization under 'Getting Started' section.
- [ ] Describe better what the project does/why it's useful in intro. 
- [ ] Add instructions for how to get help. 
- [ ] Add guidelines for contributing to project and who maintains/contributes to projects.  