### PR TITLE
WIP: Feat/fast ext2

### DIFF
--- a/cmd/params.go
+++ b/cmd/params.go
@@ -165,12 +165,9 @@ func params(cmd *cobra.Command, args []string) {
 	results := make(chan paramResult, numModels)
 	orderedResults := make([]paramResult, numModels)
 	var paramResults jsonParamResults
-	// paramSet := NewSet()
 
 	for w := 1; w <= workers; w++ {
 		go func(w int, modIndex <-chan int, results chan<- paramResult) {
-			// paramSet := make(map[string]struct{})
-			// var exists = struct{}{}
 			for i := range modIndex {
 				dir := filepath.Join(dir, modelDirs[i])
 				var extFileName string
@@ -181,9 +178,6 @@ func params(cmd *cobra.Command, args []string) {
 				}
 				r, err := parser.ParseEstimatesFromExt(filepath.Join(dir, extFileName))
 
-				// for _, s := range r.ParameterNames{
-				//	paramSet[s] = exists
-				// }
 				if err != nil {
 					results <- paramResult{
 						Index:   i,
@@ -203,10 +197,6 @@ func params(cmd *cobra.Command, args []string) {
 		}(w, models, results)
 	}
 
-
-
-
-
 	for m := 0; m < numModels; m++ {
 		models <- m
 	}
@@ -216,41 +206,45 @@ func params(cmd *cobra.Command, args []string) {
 		orderedResults[res.Index] = res
 	}
 
-	paramSet := []string{}
-	for _, res := range orderedResults{
-		results := res.Result
-		paramSet = append(paramSet, results.ParameterNames...)
-	}
-
-	paramSet = removeDuplicateValues(paramSet)
-	fmt.Println("dir," + strings.Join(paramSet, ", "))
-	for _, res := range orderedResults{
-		s := make([]string, len(paramSet))
-		for i, _ := range s {
-			s[i] = ""
-		}
-		results := res.Result
-		for i, name := range results.ParameterNames{
-			idx := index(paramSet, name)
-			values := results.EstimationLines
-			s[idx] = values[0][i]
-		}
-		fmt.Println(modelDirs[res.Index] + "," + strings.Join(s, ","))
-	}
-
 	if !Json {
-		// will only know the proper header once we have a successful run
-		headerPrinted := false
+
+		paramSet := []string{}
 		for _, res := range orderedResults {
+			results := res.Result
+			paramSet = append(paramSet, results.ParameterNames...)
+		}
+
+		paramSet = removeDuplicateValues(paramSet)
+		for i, s := range paramSet {
+			paramSet[i] = strings.ReplaceAll(s, ",", "_")
+		}
+
+		fmt.Println("dir,error,termination," + strings.Join(paramSet, ","))
+		for _, res := range orderedResults {
+			s := make([]string, len(paramSet))
+			for i, _ := range s {
+				s[i] = ""
+			}
+
+			absolutePath := dir + "/" + modelDirs[res.Index]
 			if res.Outcome == SUCCESS {
 				results := res.Result
-				if !noParamNames && !headerPrinted {
-					printParamHeader(results)
-					headerPrinted = true
+				for i, name := range results.ParameterNames {
+					idx := index(paramSet, strings.ReplaceAll(name, ",", "_"))
+					values := results.EstimationLines
+					s[idx] = values[0][i]
 				}
-				fmt.Println(modelDirs[res.Index]+ "," + strings.Join(results.EstimationLines[len(results.EstimationLines) - 1], ","))
+
+				// first code is the termination status
+				terminationCode := results.TerminationCodes[0][0]
+				fmt.Println(absolutePath + ",," + terminationCode + "," + strings.Join(s, ","))
+
+			} else if res.Outcome == ERROR {
+				errorMessage :=  res.Err.Error()
+				fmt.Println(absolutePath + "," + errorMessage + ",," + strings.Join(s, ","))
 			}
 		}
+
 		return
 	}
 

--- a/parsers/nmparser/read_ext_fast.go
+++ b/parsers/nmparser/read_ext_fast.go
@@ -27,6 +27,7 @@ func ParseEstimatesFromExt(file string) (ExtFastData, error) {
 	estimationIndex := -1
 	var paramNames []string
 	var estimationLines [][]string
+	var terminationCodes [][]string
 	var estLineDetected bool
 	scanner := bufio.NewScanner(fl)
 	for scanner.Scan() {
@@ -46,6 +47,9 @@ func ParseEstimatesFromExt(file string) (ExtFastData, error) {
 			// all lines minus the first which is the -100000000 and last which is OBJ
 			fields :=strings.Fields(line)
 			estimationLines = append(estimationLines, fields[1:len(fields)-1])
+		} else if strings.HasPrefix(line, "  -1000000007"){
+			fields := strings.Fields(line)
+			terminationCodes = append(terminationCodes, fields[1:len(fields)-1])
 		}
 	}
 	// ext file can be present but have no -1000000000 for example from a control stream generating chain values
@@ -62,6 +66,7 @@ func ParseEstimatesFromExt(file string) (ExtFastData, error) {
 		EstimationMethods: estimationMethods,
 		ParameterNames:    paramNames,
 		EstimationLines: estimationLines,
+		TerminationCodes: terminationCodes,
 	}, nil
 }
 

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -169,6 +169,7 @@ type ExtFastData struct {
 	EstimationMethods []string
 	ParameterNames    []string
 	EstimationLines   [][]string
+	TerminationCodes   [][]string
 }
 
 // MatrixData ...


### PR DESCRIPTION
Adjustments to just the `--dir` flag output in `params.go`:
- Added `error` column output if a detected .ext file failed to read in
- Modified `dir` column to output absolute path to .ext file
- Added `termination` column to output termination code found on -1000007 in .ext file.
- Modified csv output: if parameters vary amongst files in the specified directory, .csv will show all parameter names as columns and the empty values for rows/files were a give parameter was not found in. 

example: `test_batch_parameters` contains directories:
- 1:  THETA1       **THETA2**       THETA3       THETA4       THETA5       SIGMA(1,1)   OMEGA(1,1)   OMEGA(2,1)   OMEGA(2,2)
- 2: THETA1       **THETA9**       THETA3       THETA4       THETA5       SIGMA(1,1)   OMEGA(1,1)   OMEGA(2,1)   OMEGA(2,2)
- 3: empty .ext file

running `bbi nonmem params --dir test_batch_parameters` returns: 
```
dir,error,termination,THETA1,THETA2,THETA3,THETA4,THETA5,SIGMA(1_1),OMEGA(1_1),OMEGA(2_1),OMEGA(2_2),THETA9
test_batch_params/1,,0.00000E+00,2.31034E+00,5.49596E+01,4.64659E+02,-8.05722E-02,4.13030E+00,1.00000E+00,9.64407E-02,0.00000E+00,1.53571E-01,
test_batch_params/2,,0.00000E+00,2.31034E+00,,4.64659E+02,-8.05722E-02,4.13030E+00,1.00000E+00,9.64407E-02,0.00000E+00,1.53571E-01,5.49596E+01
test_batch_params/3,no ext file contents,,,,,,,,,,,
```

and R `data.table::fread` in R reads this in as:
