### PR TITLE
ParseRunDetails: parse NumberOfDataRecords for $INFN output

### DIFF
--- a/parsers/nmparser/parse_run_details.go
+++ b/parsers/nmparser/parse_run_details.go
@@ -83,6 +83,9 @@ func ParseRunDetails(lines []string) RunDetails {
 			runDetails.NumberOfObs, _ = strconv.ParseInt(replaceTrim(line, "TOT. NO. OF OBS RECS:"), 10, 64)
 		case strings.Contains(line, "NO. OF DATA RECS IN DATA SET:"):
 			runDetails.NumberOfDataRecords, _ = strconv.ParseInt(replaceTrim(line, "NO. OF DATA RECS IN DATA SET:"), 10, 64)
+		// When using $INFN, the above line isn't present (see gh-227).
+		case strings.Contains(line, "TOT. NO. OF DATA RECS:") && runDetails.NumberOfDataRecords == DefaultInt64:
+			runDetails.NumberOfDataRecords, _ = strconv.ParseInt(replaceTrim(line, "TOT. NO. OF DATA RECS:"), 10, 64)
 		// This is not reliable because TABLE statements can span multiple lines
 		// TODO: support using multi-line feature, when available
 		// case strings.Contains(line, "$TABLE NOPRINT ONEHEADER FILE="):

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -73,8 +73,45 @@ var RunDetails02Results = RunDetails{
 	[]string{""},
 }
 
+var RunDetailsInfn = []string{
+	"Days until program expires : 122",
+	"1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.2.0",
+	" ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN",
+	" #TERM:",
+	"0MINIMIZATION SUCCESSFUL",
+	" NO. OF FUNCTION EVALUATIONS USED:      352",
+	" NO. OF SIG. DIGITS IN FINAL EST.:  3.4",
+	"",
+	"#TERE:",
+	"Elapsed estimation time in seconds:     6.84",
+	"Elapsed covariance time in seconds:     3.34",
+	"This file was created using /opt/NONMEM/nm72g/run/nmfe72",
+	"Started  Tue Dec 17 18:10:55 2013",
+	"Finished Tue Dec 17 18:11:32 2013",
+	"$PROB 3.mod, double inital estimates",
+	"", // TODO, pass full path control stream file name into ParseRunDetails
+	// 3.mod; initial estimate of inter-subject variability (matrix). also ETA
+	"#METH: First Order Conditional Estimation with Interaction",
+	"$DATA ../../derived/mock1.csv IGNORE=C",
+	"TOT. NO. OF INDIVIDUALS:       50",
+	"TOT. NO. OF OBS RECS:      442",
+	// Difference with RunDetails01Results: Drop "NO. OF DATA RECS
+	// IN DATA SET:" line and add the one below to mimic $INFN
+	// output.
+	"TOT. NO. OF DATA RECS:      492",
+	"$TABLE NOPRINT ONEHEADER FILE=./1.tab",
+}
+
 func TestParseRunDetails(t *testing.T) {
 	parsedData := ParseRunDetails(RunDetails01)
+	if !reflect.DeepEqual(parsedData, RunDetails01Results) {
+		t.Log("\nGOT: ", parsedData, "\n Expected: ", RunDetails01Results)
+		t.Fail()
+	}
+}
+
+func TestParseRunDetailsInfn(t *testing.T) {
+	parsedData := ParseRunDetails(RunDetailsInfn)
 	if !reflect.DeepEqual(parsedData, RunDetails01Results) {
 		t.Log("\nGOT: ", parsedData, "\n Expected: ", RunDetails01Results)
 		t.Fail()

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -37,7 +37,7 @@ var RunDetails01Results = RunDetails{
 	"Tue Dec 17 18:11:32 2013",
 	6.84,
 	3.34,
-	10.5, // this is made up, not for an actual run output
+	0, // not specified in test RunDetails01
 	352,
 	3.4,
 	"3.mod, double inital estimates",
@@ -47,8 +47,8 @@ var RunDetails01Results = RunDetails{
 	50,
 	442,
 	492,
-	[]string{"-999999999"},
-	[]string{""},
+	[]string{},
+	[]string{},
 }
 
 var RunDetails02 = "../../testdata/2.lst"
@@ -75,7 +75,6 @@ var RunDetails02Results = RunDetails{
 
 func TestParseRunDetails(t *testing.T) {
 	parsedData := ParseRunDetails(RunDetails01)
-	parsedData.OutputFilesUsed = []string{""}
 	if !reflect.DeepEqual(parsedData, RunDetails01Results) {
 		t.Log("\nGOT: ", parsedData, "\n Expected: ", RunDetails01Results)
 		t.Fail()

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -37,7 +37,7 @@ var RunDetails01Results = RunDetails{
 	"Tue Dec 17 18:11:32 2013",
 	6.84,
 	3.34,
-	0, // not specified in test RunDetails01
+	DefaultFloat64, // not specified in test RunDetails01
 	352,
 	3.4,
 	"3.mod, double inital estimates",

--- a/parsers/nmparser/structs.go
+++ b/parsers/nmparser/structs.go
@@ -197,6 +197,7 @@ func NewRunDetails() RunDetails {
 		RunEnd:              DefaultString,
 		EstimationTime:      DefaultFloat64,
 		CovarianceTime:      DefaultFloat64,
+		CpuTime:             DefaultFloat64,
 		FunctionEvaluations: DefaultInt64,
 		SignificantDigits:   DefaultFloat64,
 		ProblemText:         DefaultString,


### PR DESCRIPTION
In gh-227, @dpolhamus reported that the number of data records wasn't being set properly when `$INFN` is used.  The lst file doesn't have the "TOT. NO. OF DATA RECS:" line that `ParseRunDetails` looks for, but there is a "NO. OF DATA RECS IN DATA SET:" line.  The last commit of this series falls back to using that value, assuming there is only one "NO. OF DATA RECS IN DATA SET:" line and that its value is a reasonable value for `NumberOfDataRecords`.

The first two commits are related fixes (or at least what I think are fixes).  One of them gets the tests in `parsers/nmparser/parse_run_details_test.go` to a passing state.  @seth127, would you prefer that I drop these commits and add the test in metrumresearchgroup/bbitest instead?

(Also, I'm being a bit lazy with the new test and duplicating `RunDetails01Results` aside from one item.  I can rework that...)

```
$ (cd parsers/nmparser && go test -v -run TestParseRunDetails)
=== RUN   TestParseRunDetails
--- PASS: TestParseRunDetails (0.00s)
=== RUN   TestParseRunDetailsInfn
--- PASS: TestParseRunDetailsInfn (0.00s)
PASS
ok  	bbi/parsers/nmparser	0.195s
```

---

And here some of my manual tests with bbr's `inst/model/nonmem/basic/1/1.lst`.

```sh
# On bbr's 1.1.2.7001-7-g1802d63, no changes to lst file.
$ grep 'DATA RECS' inst/model/nonmem/basic/1/1.lst
 NO. OF DATA RECS IN DATA SET:      799
$ bbi nonmem summary --json inst/model/nonmem/basic/1/1 | jq .run_details.number_of_data_records

# Change lst file to match gh-227 case: "TOT. NO. OF DATA RECS"
# but no "NO. OF DATA RECS IN DATA SET"
$ grep 'DATA RECS' inst/model/nonmem/basic/1/1.lst
 TOT. NO. OF DATA RECS:      1707
$ bbi nonmem summary --json inst/model/nonmem/basic/1/1 | jq .run_details.number_of_data_records
1707
```
