### PR TITLE
cmd: convert cobra style commands to testable components

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -39,41 +39,6 @@ var (
 	regex      bool
 )
 
-// cleanCmd represents the clean command.
-var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "clean files and folders",
-	Long: `
-glob examples:
-bbi clean *.mod // anything with extension .mod
-bbi clean *.mod --noFolders // anything with extension .mod
-bbi clean run* // anything starting with run
-regular expression examples:
-
-bbi clean ^run --regex // anything beginning with the letters run
-bbi clean ^run -v --regex // print out files and folders that will be deleted 
-bbi clean ^run --filesOnly --regex // only remove matching files 
-bbi clean _est_ --dirsOnly --regex // only remove matching folders  
-bbi clean _est_ --dirsOnly --preview --regex // show what output would be if clean occured but don't actually clean 
-bbi clean "run009.[^mod]" --regex // all matching run009.<ext> but not .mod files
-bbi clean "run009.(mod|lst)$" --regex // match run009.lst and run009.mod
-
-can also clean via the opposite of a match with inverse
-
-bbi clean ".modt{0,1}$" --filesOnly --inverse --regex // clean all files not matching .mod or .modt
-
-clean copied files via
-
-bbi clean --copiedRuns="run001"
-bbi clean --copiedRuns="run[001:010]"
-
-can be a comma separated list as well
-
-bbi clean --copiedRuns="run[001:010],run100"
- `,
-	RunE: clean,
-}
-
 func clean(cmd *cobra.Command, args []string) error {
 	if debug {
 		viper.Debug()
@@ -184,11 +149,45 @@ func getMatches(s []string, expr string, regex bool) ([]string, error) {
 	}
 }
 
-func init() {
-	nonmemCmd.AddCommand(cleanCmd)
-	cleanCmd.Flags().BoolVar(&dirsOnly, "dirsOnly", false, "only match and clean directories")
-	cleanCmd.Flags().BoolVar(&filesOnly, "filesOnly", false, "only match and clean files")
-	cleanCmd.Flags().BoolVar(&inverse, "inverse", false, "inverse selection from the given regex match criteria")
-	cleanCmd.Flags().BoolVar(&regex, "regex", false, "use regular expression to match instead of glob")
-	cleanCmd.Flags().StringVar(&copiedRuns, "copiedRuns", "", "run names")
+func NewCleanCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clean",
+		Short: "clean files and folders",
+		Long: `
+glob examples:
+bbi clean *.mod // anything with extension .mod
+bbi clean *.mod --noFolders // anything with extension .mod
+bbi clean run* // anything starting with run
+regular expression examples:
+
+bbi clean ^run --regex // anything beginning with the letters run
+bbi clean ^run -v --regex // print out files and folders that will be deleted
+bbi clean ^run --filesOnly --regex // only remove matching files
+bbi clean _est_ --dirsOnly --regex // only remove matching folders
+bbi clean _est_ --dirsOnly --preview --regex // show what output would be if clean occured but don't actually clean
+bbi clean "run009.[^mod]" --regex // all matching run009.<ext> but not .mod files
+bbi clean "run009.(mod|lst)$" --regex // match run009.lst and run009.mod
+
+can also clean via the opposite of a match with inverse
+
+bbi clean ".modt{0,1}$" --filesOnly --inverse --regex // clean all files not matching .mod or .modt
+
+clean copied files via
+
+bbi clean --copiedRuns="run001"
+bbi clean --copiedRuns="run[001:010]"
+
+can be a comma separated list as well
+
+bbi clean --copiedRuns="run[001:010],run100"
+ `,
+		RunE: clean,
+	}
+
+	cmd.Flags().BoolVar(&dirsOnly, "dirsOnly", false, "only match and clean directories")
+	cmd.Flags().BoolVar(&filesOnly, "filesOnly", false, "only match and clean files")
+	cmd.Flags().BoolVar(&inverse, "inverse", false, "inverse selection from the given regex match criteria")
+	cmd.Flags().BoolVar(&regex, "regex", false, "use regular expression to match instead of glob")
+	cmd.Flags().StringVar(&copiedRuns, "copiedRuns", "", "run names")
+	return cmd
 }

--- a/cmd/covcor.go
+++ b/cmd/covcor.go
@@ -30,14 +30,6 @@ bbi nonmem covcor run001/run001
 bbi nonmem covcor run001/run001.cov
  `
 
-// runCmd represents the run command.
-var covcorCmd = &cobra.Command{
-	Use:   "covcor",
-	Short: "load .cov and .cor output from a model run",
-	Long:  covcorLongDescription,
-	Run:   covcor,
-}
-
 func covcor(cmd *cobra.Command, args []string) {
 	if debug {
 		viper.Debug()
@@ -51,6 +43,12 @@ func covcor(cmd *cobra.Command, args []string) {
 	jsonRes, _ := json.MarshalIndent(results, "", "\t")
 	fmt.Printf("%s\n", jsonRes)
 }
-func init() {
-	nonmemCmd.AddCommand(covcorCmd)
+
+func NewCovcorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "covcor",
+		Short: "load .cov and .cor output from a model run",
+		Long:  covcorLongDescription,
+		Run:   covcor,
+	}
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,15 +18,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// RunCmd represents the run command.
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Create configuration file with defaults",
-	Long: `Run bbi init to create a bbi.yaml configuration file in the current directory.
- `,
-	RunE: initializer,
-}
-
 func initializer(cmd *cobra.Command, _ []string) error {
 	fs := afero.NewOsFs()
 
@@ -92,11 +83,18 @@ func initializer(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func init() {
-	RootCmd.AddCommand(initCmd)
+func NewInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create configuration file with defaults",
+		Long: `Run bbi init to create a bbi.yaml configuration file in the current directory.
+ `,
+		RunE: initializer,
+	}
 
 	const directory string = "dir"
-	initCmd.Flags().StringSlice(directory, []string{}, "A directory in which to look for NonMem Installations")
+	cmd.Flags().StringSlice(directory, []string{}, "A directory in which to look for NonMem Installations")
+	return cmd
 }
 
 // Evaluates if a specific directory path is nonmem-ish.

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -344,21 +344,19 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 
 // End Scalable method definitions
 
-// runCmd represents the run command.
-var localCmd = &cobra.Command{
-	Use:   "local",
-	Short: "local specifies to run a (set of) models locally",
-	Long:  runLongDescription,
-	Run:   local,
-}
-
-func init() {
-	runCmd.AddCommand(localCmd)
+func NewLocalCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "local",
+		Short: "local specifies to run a (set of) models locally",
+		Long:  runLongDescription,
+		Run:   local,
+	}
 
 	childDirIdentifier := "create_child_dirs"
-	localCmd.PersistentFlags().Bool(childDirIdentifier, true, "Indicates whether or not local branch execution"+
+	cmd.PersistentFlags().Bool(childDirIdentifier, true, "Indicates whether or not local branch execution"+
 		"should create a new subdirectory with the output_dir variable as its name and execute in that directory")
-	errpanic(viper.BindPFlag("local."+childDirIdentifier, localCmd.PersistentFlags().Lookup(childDirIdentifier)))
+	errpanic(viper.BindPFlag("local."+childDirIdentifier, cmd.PersistentFlags().Lookup(childDirIdentifier)))
+	return cmd
 }
 
 func local(_ *cobra.Command, args []string) {

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -165,72 +165,79 @@ type NonMemModel struct {
 
 var nonmemLongDescription string = fmt.Sprintf("\n%s\n\n%s\n\n%s\n", runLongDescription, summaryLongDescription, covcorLongDescription)
 
-// RunCmd represents the run command.
-var nonmemCmd = &cobra.Command{
-	Use:   "nonmem",
-	Short: "nonmem a (set of) models locally or on the grid",
-	Long:  nonmemLongDescription,
-	Run:   nonmem,
-}
-
 func nonmem(_ *cobra.Command, _ []string) {
 	println(nonmemLongDescription)
 }
 
-func init() {
-	RootCmd.AddCommand(nonmemCmd)
+func NewNonmemCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nonmem",
+		Short: "nonmem a (set of) models locally or on the grid",
+		Long:  nonmemLongDescription,
+		Run:   nonmem,
+	}
 
 	// NM Selector
 	const nmVersionIdentifier string = "nm_version"
-	nonmemCmd.PersistentFlags().String(nmVersionIdentifier, "", "Version of nonmem from the configuration list to use")
-	errpanic(viper.BindPFlag(nmVersionIdentifier, nonmemCmd.PersistentFlags().Lookup(nmVersionIdentifier)))
+	cmd.PersistentFlags().String(nmVersionIdentifier, "", "Version of nonmem from the configuration list to use")
+	errpanic(viper.BindPFlag(nmVersionIdentifier, cmd.PersistentFlags().Lookup(nmVersionIdentifier)))
 
 	// Parallelization Components
 	const parallelIdentifier string = "parallel"
-	nonmemCmd.PersistentFlags().Bool(parallelIdentifier, false, "Whether or not to run nonmem in parallel mode")
-	errpanic(viper.BindPFlag(parallelIdentifier, nonmemCmd.PersistentFlags().Lookup(parallelIdentifier)))
+	cmd.PersistentFlags().Bool(parallelIdentifier, false, "Whether or not to run nonmem in parallel mode")
+	errpanic(viper.BindPFlag(parallelIdentifier, cmd.PersistentFlags().Lookup(parallelIdentifier)))
 
 	const parallelCompletionTimeoutIdentifier string = "parallel_timeout"
-	nonmemCmd.PersistentFlags().Int(parallelCompletionTimeoutIdentifier, 2147483647, "The amount of time to wait for parallel operations in nonmem before timing out")
-	errpanic(viper.BindPFlag(parallelCompletionTimeoutIdentifier, nonmemCmd.PersistentFlags().Lookup(parallelCompletionTimeoutIdentifier)))
+	cmd.PersistentFlags().Int(parallelCompletionTimeoutIdentifier, 2147483647, "The amount of time to wait for parallel operations in nonmem before timing out")
+	errpanic(viper.BindPFlag(parallelCompletionTimeoutIdentifier, cmd.PersistentFlags().Lookup(parallelCompletionTimeoutIdentifier)))
 
 	const mpiExecPathIdentifier string = "mpi_exec_path"
-	nonmemCmd.PersistentFlags().String(mpiExecPathIdentifier, "/usr/local/mpich3/bin/mpiexec", "The fully qualified path to mpiexec. Used for nonmem parallel operations")
-	errpanic(viper.BindPFlag(mpiExecPathIdentifier, nonmemCmd.PersistentFlags().Lookup(mpiExecPathIdentifier)))
+	cmd.PersistentFlags().String(mpiExecPathIdentifier, "/usr/local/mpich3/bin/mpiexec", "The fully qualified path to mpiexec. Used for nonmem parallel operations")
+	errpanic(viper.BindPFlag(mpiExecPathIdentifier, cmd.PersistentFlags().Lookup(mpiExecPathIdentifier)))
 
 	const parafileIdentifier string = "parafile"
-	nonmemCmd.PersistentFlags().String(parafileIdentifier, "", "Location of a user-provided parafile to use for parallel execution")
-	errpanic(viper.BindPFlag(parafileIdentifier, nonmemCmd.PersistentFlags().Lookup(parafileIdentifier)))
+	cmd.PersistentFlags().String(parafileIdentifier, "", "Location of a user-provided parafile to use for parallel execution")
+	errpanic(viper.BindPFlag(parafileIdentifier, cmd.PersistentFlags().Lookup(parafileIdentifier)))
 
 	const nmQualIdentifier string = "nmqual"
-	nonmemCmd.PersistentFlags().Bool(nmQualIdentifier, false, "Whether or not to execute with nmqual (autolog.pl")
-	errpanic(viper.BindPFlag(nmQualIdentifier, nonmemCmd.PersistentFlags().Lookup(nmQualIdentifier)))
+	cmd.PersistentFlags().Bool(nmQualIdentifier, false, "Whether or not to execute with nmqual (autolog.pl")
+	errpanic(viper.BindPFlag(nmQualIdentifier, cmd.PersistentFlags().Lookup(nmQualIdentifier)))
 
 	// NMFE Options
 	const nmfeGroup string = "nmfe_options"
 	const licFileIdentifier string = "licfile"
-	nonmemCmd.PersistentFlags().String(licFileIdentifier, "", "RAW NMFE OPTION - Specify a license file to use with NMFE (Nonmem)")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+licFileIdentifier, nonmemCmd.PersistentFlags().Lookup(licFileIdentifier)))
+	cmd.PersistentFlags().String(licFileIdentifier, "", "RAW NMFE OPTION - Specify a license file to use with NMFE (Nonmem)")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+licFileIdentifier, cmd.PersistentFlags().Lookup(licFileIdentifier)))
 
 	const prSameIdentifier string = "prsame"
-	nonmemCmd.PersistentFlags().Bool(prSameIdentifier, false, "RAW NMFE OPTION - Indicates to nonmem that the PREDPP compilation step should be skipped")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+prSameIdentifier, nonmemCmd.PersistentFlags().Lookup(prSameIdentifier)))
+	cmd.PersistentFlags().Bool(prSameIdentifier, false, "RAW NMFE OPTION - Indicates to nonmem that the PREDPP compilation step should be skipped")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+prSameIdentifier, cmd.PersistentFlags().Lookup(prSameIdentifier)))
 
 	const backgroundIdentifier string = "background"
-	nonmemCmd.PersistentFlags().Bool(backgroundIdentifier, false, "RAW NMFE OPTION - Tells nonmem not to scan StdIn for control characters")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+backgroundIdentifier, nonmemCmd.PersistentFlags().Lookup(backgroundIdentifier)))
+	cmd.PersistentFlags().Bool(backgroundIdentifier, false, "RAW NMFE OPTION - Tells nonmem not to scan StdIn for control characters")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+backgroundIdentifier, cmd.PersistentFlags().Lookup(backgroundIdentifier)))
 
 	const prCompileIdentifier string = "prcompile"
-	nonmemCmd.PersistentFlags().Bool(prCompileIdentifier, false, "RAW NMFE OPTION - Forces PREDPP compilation")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+prCompileIdentifier, nonmemCmd.PersistentFlags().Lookup(prCompileIdentifier)))
+	cmd.PersistentFlags().Bool(prCompileIdentifier, false, "RAW NMFE OPTION - Forces PREDPP compilation")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+prCompileIdentifier, cmd.PersistentFlags().Lookup(prCompileIdentifier)))
 
 	const noBuildIdentifier string = "nobuild"
-	nonmemCmd.PersistentFlags().Bool(noBuildIdentifier, false, "RAW NMFE OPTION - Skips recompiling and rebuilding on nonmem executable")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+noBuildIdentifier, nonmemCmd.PersistentFlags().Lookup(noBuildIdentifier)))
+	cmd.PersistentFlags().Bool(noBuildIdentifier, false, "RAW NMFE OPTION - Skips recompiling and rebuilding on nonmem executable")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+noBuildIdentifier, cmd.PersistentFlags().Lookup(noBuildIdentifier)))
 
 	const maxLimIdentifier string = "maxlim"
-	nonmemCmd.PersistentFlags().Int(maxLimIdentifier, 100, "RAW NMFE OPTION - Set the maximum values set for the buffers used by Nonmem")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+maxLimIdentifier, nonmemCmd.PersistentFlags().Lookup(maxLimIdentifier)))
+	cmd.PersistentFlags().Int(maxLimIdentifier, 100, "RAW NMFE OPTION - Set the maximum values set for the buffers used by Nonmem")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+maxLimIdentifier, cmd.PersistentFlags().Lookup(maxLimIdentifier)))
+
+	cmd.AddCommand(NewCleanCmd())
+	cmd.AddCommand(NewCovcorCmd())
+	cmd.AddCommand(NewProbsCmd())
+	cmd.AddCommand(NewRecleanCmd())
+	cmd.AddCommand(NewRunCmd())
+	cmd.AddCommand(NewScaffoldCmd())
+	cmd.AddCommand(NewSummaryCmd())
+
+	return cmd
 }
 
 // "Copies" a file by reading its content (optionally updating the path).

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -33,16 +33,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// probsCmd represents the command to get information about a given modeling project.
-var probsCmd = &cobra.Command{
-	Use:   "probs",
-	Short: "summarize information about project",
-	Long: `get information about models in the project: 
-nmu project
- `,
-	RunE: probs,
-}
-
 func probs(_ *cobra.Command, args []string) error {
 	if debug {
 		viper.Debug()
@@ -86,8 +76,15 @@ func probs(_ *cobra.Command, args []string) error {
 
 	return nil
 }
-func init() {
-	nonmemCmd.AddCommand(probsCmd)
+func NewProbsCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "probs",
+		Short: "summarize information about project",
+		Long: `get information about models in the project:
+nmu project
+ `,
+		RunE: probs,
+	}
 }
 
 type runSummary struct {

--- a/cmd/reclean.go
+++ b/cmd/reclean.go
@@ -24,16 +24,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// cleanCmd represents the clean command.
-var recleanCmd = &cobra.Command{
-	Use:   "reclean",
-	Short: "clean files in an estimation directory by clean level",
-	Long: `
-	bbi reclean run001_est_01
- `,
-	RunE: reclean,
-}
-
 func reclean(cmd *cobra.Command, args []string) error {
 	if debug {
 		viper.Debug()
@@ -46,9 +36,18 @@ func reclean(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-func init() {
-	nonmemCmd.AddCommand(recleanCmd)
 
-	recleanCmd.Flags().Int("recleanLvl", 0, "clean level to apply")
-	errpanic(viper.BindPFlag("recleanLvl", recleanCmd.Flags().Lookup("recleanLvl")))
+func NewRecleanCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "reclean",
+		Short: "clean files in an estimation directory by clean level",
+		Long: `
+	bbi reclean run001_est_01
+ `,
+		RunE: reclean,
+	}
+
+	cmd.Flags().Int("recleanLvl", 0, "clean level to apply")
+	errpanic(viper.BindPFlag("recleanLvl", cmd.Flags().Lookup("recleanLvl")))
+	return cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,12 +49,6 @@ var (
 	executionWaitGroup sync.WaitGroup
 )
 
-// RootCmd represents the base command when called without any subcommands.
-var RootCmd = &cobra.Command{
-	Use:   "bbi",
-	Short: "manage and execute models",
-	Long:  fmt.Sprintf("bbi CLI version %s", VERSION),
-}
 
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
@@ -62,14 +56,22 @@ func Execute(build string) {
 	if build != "" {
 		VERSION = fmt.Sprintf("%s-%s", VERSION, build)
 	}
-	RootCmd.Long = fmt.Sprintf("bbi cli version %s", VERSION)
-	if err := RootCmd.Execute(); err != nil {
+	cmd := NewRootCmd()
+	cmd.Long = fmt.Sprintf("bbi cli version %s", VERSION)
+	if err := cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}
 }
 
-func init() {
+// RootCmd represents the base command when called without any subcommands.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bbi",
+		Short: "manage and execute models",
+		Long:  fmt.Sprintf("bbi CLI version %s", VERSION),
+	}
+
 	// Set random for application
 	rand.Seed(time.Now().UnixNano())
 
@@ -82,14 +84,20 @@ func init() {
 	// Here you will define your flags and configuration settings.
 	// Cobra supports Persistent Flags, which, if defined here,
 	// will be global for your application.
-	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
-	RootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug mode")
-	errpanic(viper.BindPFlag("debug", RootCmd.PersistentFlags().Lookup("debug"))) // Bind Debug to viper
-	RootCmd.PersistentFlags().IntVar(&threads, "threads", 4, "number of threads to execute with locally or nodes to execute on in parallel")
-	errpanic(viper.BindPFlag("threads", RootCmd.PersistentFlags().Lookup("threads"))) // Update to make sure viper binds to the flag
-	RootCmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")
-	errpanic(viper.BindPFlag("json", RootCmd.PersistentFlags().Lookup("json"))) // Bind to viper
-	RootCmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	cmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "debug mode")
+	errpanic(viper.BindPFlag("debug", cmd.PersistentFlags().Lookup("debug"))) // Bind Debug to viper
+	cmd.PersistentFlags().IntVar(&threads, "threads", 4, "number of threads to execute with locally or nodes to execute on in parallel")
+	errpanic(viper.BindPFlag("threads", cmd.PersistentFlags().Lookup("threads"))) // Update to make sure viper binds to the flag
+	cmd.PersistentFlags().BoolVar(&Json, "json", false, "json tree of output, if possible")
+	errpanic(viper.BindPFlag("json", cmd.PersistentFlags().Lookup("json"))) // Bind to viper
+	cmd.PersistentFlags().BoolVarP(&preview, "preview", "p", false, "preview action, but don't actually run command")
+
+	cmd.AddCommand(NewInitCmd())
+	cmd.AddCommand(NewNonmemCmd())
+	cmd.AddCommand(NewVersionCmd())
+
+	return cmd
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,81 +54,83 @@ const postProcessingScriptTemplate string = `#!/bin/bash
 {{ .Script }}
 `
 
-// RunCmd represents the run command.
-var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "run a (set of) models locally or on the grid",
-	Long:  runLongDescription,
-	Run:   run,
-}
-
 func run(_ *cobra.Command, _ []string) {
 	println(runLongDescription)
 }
 
-func init() {
+func NewRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "run a (set of) models locally or on the grid",
+		Long:  runLongDescription,
+		Run:   run,
+	}
+
 	// String Variables
-	// runCmd.PersistentFlags().String("cacheDir", "", "directory path for cache of nonmem executables for NM7.4+")
-	// viper.BindPFlag("cacheDir", runCmd.PersistentFlags().Lookup("cacheDir"))
+	// cmd.PersistentFlags().String("cacheDir", "", "directory path for cache of nonmem executables for NM7.4+")
+	// viper.BindPFlag("cacheDir", cmd.PersistentFlags().Lookup("cacheDir"))
 
-	// runCmd.PersistentFlags().String("cacheExe", "", "name of executable stored in cache")
-	// viper.BindPFlag("cacheExe", runCmd.PersistentFlags().Lookup("cacheExe"))
+	// cmd.PersistentFlags().String("cacheExe", "", "name of executable stored in cache")
+	// viper.BindPFlag("cacheExe", cmd.PersistentFlags().Lookup("cacheExe"))
 
-	// runCmd.PersistentFlags().String("saveExe", "", "what to name the executable when stored in cache")
-	// viper.BindPFlag("saveExe", runCmd.PersistentFlags().Lookup("saveExe"))
+	// cmd.PersistentFlags().String("saveExe", "", "what to name the executable when stored in cache")
+	// viper.BindPFlag("saveExe", cmd.PersistentFlags().Lookup("saveExe"))
 
-	runCmd.PersistentFlags().String("output_dir", "{{ .Name }}", "Go template for the output directory to use for storging details of each executed model")
-	errpanic(viper.BindPFlag("output_dir", runCmd.PersistentFlags().Lookup("output_dir")))
+	cmd.PersistentFlags().String("output_dir", "{{ .Name }}", "Go template for the output directory to use for storging details of each executed model")
+	errpanic(viper.BindPFlag("output_dir", cmd.PersistentFlags().Lookup("output_dir")))
 	viper.SetDefault("output_dir", "{{ .Name }}")
 
 	// Int Variables
-	runCmd.PersistentFlags().Int("clean_lvl", 1, "clean level used for file output from a given (set of) runs")
-	errpanic(viper.BindPFlag("clean_lvl", runCmd.PersistentFlags().Lookup("clean_lvl")))
+	cmd.PersistentFlags().Int("clean_lvl", 1, "clean level used for file output from a given (set of) runs")
+	errpanic(viper.BindPFlag("clean_lvl", cmd.PersistentFlags().Lookup("clean_lvl")))
 	// TODO: these are likely not meangingful as should be set in configlib, but want to configm
 	viper.SetDefault("clean_lvl", 1)
 
-	runCmd.PersistentFlags().Int("copy_lvl", 0, "copy level used for file output from a given (set of) runs")
-	errpanic(viper.BindPFlag("copy_lvl", runCmd.PersistentFlags().Lookup("copy_lvl")))
+	cmd.PersistentFlags().Int("copy_lvl", 0, "copy level used for file output from a given (set of) runs")
+	errpanic(viper.BindPFlag("copy_lvl", cmd.PersistentFlags().Lookup("copy_lvl")))
 	viper.SetDefault("copy_lvl", 0)
 
-	// runCmd.PersistentFlags().Int("gitignoreLvl", 0, "gitignore lvl for a given (set of) runs")
-	// viper.BindPFlag("gitignoreLvl", runCmd.PersistentFlags().Lookup("gitignoreLvl"))
+	// cmd.PersistentFlags().Int("gitignoreLvl", 0, "gitignore lvl for a given (set of) runs")
+	// viper.BindPFlag("gitignoreLvl", cmd.PersistentFlags().Lookup("gitignoreLvl"))
 	// viper.SetDefault("gitignoreLvl", 1)
 
 	// Bool Variables
-	runCmd.PersistentFlags().Bool("git", false, "whether git is used")
-	errpanic(viper.BindPFlag("git", runCmd.PersistentFlags().Lookup("git")))
+	cmd.PersistentFlags().Bool("git", false, "whether git is used")
+	errpanic(viper.BindPFlag("git", cmd.PersistentFlags().Lookup("git")))
 	viper.SetDefault("git", true)
 
-	runCmd.PersistentFlags().Bool("overwrite", false, "Whether or not to remove existing output directories if they are present")
-	errpanic(viper.BindPFlag("overwrite", runCmd.PersistentFlags().Lookup("overwrite")))
+	cmd.PersistentFlags().Bool("overwrite", false, "Whether or not to remove existing output directories if they are present")
+	errpanic(viper.BindPFlag("overwrite", cmd.PersistentFlags().Lookup("overwrite")))
 	viper.SetDefault("overwrite", false)
 
 	const configIdentifier string = "config"
-	runCmd.PersistentFlags().String(configIdentifier, "", "Path (relative or absolute) to another bbi.yaml to load")
-	errpanic(viper.BindPFlag(configIdentifier, runCmd.PersistentFlags().Lookup(configIdentifier)))
+	cmd.PersistentFlags().String(configIdentifier, "", "Path (relative or absolute) to another bbi.yaml to load")
+	errpanic(viper.BindPFlag(configIdentifier, cmd.PersistentFlags().Lookup(configIdentifier)))
 
 	const saveconfig string = "save_config"
-	runCmd.PersistentFlags().Bool(saveconfig, true, "Whether or not to save the existing configuration to a file with the model")
-	errpanic(viper.BindPFlag(saveconfig, runCmd.PersistentFlags().Lookup(saveconfig)))
+	cmd.PersistentFlags().Bool(saveconfig, true, "Whether or not to save the existing configuration to a file with the model")
+	errpanic(viper.BindPFlag(saveconfig, cmd.PersistentFlags().Lookup(saveconfig)))
 
 	const delayIdentifier string = "delay"
-	runCmd.PersistentFlags().Int(delayIdentifier, 0, "Selects a random number of seconds between 1 and this value to stagger / jitter job execution. Assists in dealing with large volumes of work dealing with the same data set. May avoid NMTRAN issues about not being able read / close files")
-	errpanic(viper.BindPFlag(delayIdentifier, runCmd.PersistentFlags().Lookup(delayIdentifier)))
+	cmd.PersistentFlags().Int(delayIdentifier, 0, "Selects a random number of seconds between 1 and this value to stagger / jitter job execution. Assists in dealing with large volumes of work dealing with the same data set. May avoid NMTRAN issues about not being able read / close files")
+	errpanic(viper.BindPFlag(delayIdentifier, cmd.PersistentFlags().Lookup(delayIdentifier)))
 
 	const logFileIdentifier string = "log_file"
-	runCmd.PersistentFlags().String(logFileIdentifier, "", "If populated, specifies the file into which to store the output / logging details from bbi")
-	errpanic(viper.BindPFlag(logFileIdentifier, runCmd.PersistentFlags().Lookup(logFileIdentifier)))
+	cmd.PersistentFlags().String(logFileIdentifier, "", "If populated, specifies the file into which to store the output / logging details from bbi")
+	errpanic(viper.BindPFlag(logFileIdentifier, cmd.PersistentFlags().Lookup(logFileIdentifier)))
 
 	const postExecutionHookIdentifier string = "post_work_executable"
-	runCmd.PersistentFlags().String(postExecutionHookIdentifier, "", "A script or binary to run when job execution completes or fails")
-	errpanic(viper.BindPFlag(postExecutionHookIdentifier, runCmd.PersistentFlags().Lookup(postExecutionHookIdentifier)))
+	cmd.PersistentFlags().String(postExecutionHookIdentifier, "", "A script or binary to run when job execution completes or fails")
+	errpanic(viper.BindPFlag(postExecutionHookIdentifier, cmd.PersistentFlags().Lookup(postExecutionHookIdentifier)))
 
 	const additionalEnvIdentifier string = "additional_post_work_envs"
-	runCmd.PersistentFlags().StringSlice(additionalEnvIdentifier, []string{}, "Any additional values (as ENV KEY=VALUE) to provide for the post execution environment")
-	errpanic(viper.BindPFlag(additionalEnvIdentifier, runCmd.PersistentFlags().Lookup(additionalEnvIdentifier)))
+	cmd.PersistentFlags().StringSlice(additionalEnvIdentifier, []string{}, "Any additional values (as ENV KEY=VALUE) to provide for the post execution environment")
+	errpanic(viper.BindPFlag(additionalEnvIdentifier, cmd.PersistentFlags().Lookup(additionalEnvIdentifier)))
 
-	nonmemCmd.AddCommand(runCmd)
+	cmd.AddCommand(NewLocalCmd())
+	cmd.AddCommand(NewSgeCmd())
+
+	return cmd
 }
 
 type PostWorkExecutor interface {

--- a/cmd/scaffold.go
+++ b/cmd/scaffold.go
@@ -26,18 +26,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// scaffoldCmd represents the clean command.
-var scaffoldCmd = &cobra.Command{
-	Use:   "scaffold",
-	Short: "scaffold directory structures",
-	Long: `
-	nmu scaffold --cacheDir=nmcache
-
-	nmu scaffold --cacheDir=../nmcache --preview // show where the cache dir would be created
- `,
-	RunE: scaffold,
-}
-
 func scaffold(cmd *cobra.Command, args []string) error {
 	if debug {
 		viper.Debug()
@@ -80,8 +68,20 @@ func scaffold(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-func init() {
-	nonmemCmd.AddCommand(scaffoldCmd)
-	scaffoldCmd.Flags().String("cacheDir", "", "create cache directory at path/name")
-	errpanic(viper.BindPFlag("cacheDir", scaffoldCmd.Flags().Lookup("cacheDir")))
+
+func NewScaffoldCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "scaffold",
+		Short: "scaffold directory structures",
+		Long: `
+	nmu scaffold --cacheDir=nmcache
+
+	nmu scaffold --cacheDir=../nmcache --preview // show where the cache dir would be created
+ `,
+		RunE: scaffold,
+	}
+
+	cmd.Flags().String("cacheDir", "", "create cache directory at path/name")
+	errpanic(viper.BindPFlag("cacheDir", cmd.Flags().Lookup("cacheDir")))
+	return cmd
 }

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -154,21 +154,19 @@ func (l SGEModel) Cleanup(_ *turnstile.ChannelMap) {
 
 //End Scalable method definitions
 
-// runCmd represents the run command.
-var sgeCMD = &cobra.Command{
-	Use:   "sge",
-	Short: "sge specifies to run a (set of) models on the Sun Grid Engine",
-	Long:  runLongDescription,
-	Run:   sge,
-}
-
 func errpanic(err error) {
 	if err != nil {
 		panic(err)
 	}
 }
-func init() {
-	runCmd.AddCommand(sgeCMD)
+
+func NewSgeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sge",
+		Short: "sge specifies to run a (set of) models on the Sun Grid Engine",
+		Long:  runLongDescription,
+		Run:   sge,
+	}
 
 	bbi, err := os.Executable()
 
@@ -177,12 +175,13 @@ func init() {
 	}
 
 	//String Variables
-	sgeCMD.PersistentFlags().String("bbi_binary", bbi, "directory path for bbi to be called in goroutines (SGE Execution)")
-	errpanic(viper.BindPFlag("bbi_binary", sgeCMD.PersistentFlags().Lookup("bbi_binary")))
+	cmd.PersistentFlags().String("bbi_binary", bbi, "directory path for bbi to be called in goroutines (SGE Execution)")
+	errpanic(viper.BindPFlag("bbi_binary", cmd.PersistentFlags().Lookup("bbi_binary")))
 
 	const gridNamePrefixIdentifier string = "grid_name_prefix"
-	sgeCMD.PersistentFlags().String(gridNamePrefixIdentifier, "", "Any prefix you wish to add to the name of jobs being submitted to the grid")
-	errpanic(viper.BindPFlag(gridNamePrefixIdentifier, sgeCMD.PersistentFlags().Lookup(gridNamePrefixIdentifier)))
+	cmd.PersistentFlags().String(gridNamePrefixIdentifier, "", "Any prefix you wish to add to the name of jobs being submitted to the grid")
+	errpanic(viper.BindPFlag(gridNamePrefixIdentifier, cmd.PersistentFlags().Lookup(gridNamePrefixIdentifier)))
+	return cmd
 }
 
 func sge(_ *cobra.Command, args []string) {

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -40,15 +40,6 @@ bbi nonmem summary run001/run001
 bbi nonmem summary run001/run001.lst
 bbi nonmem summary run001/run001.res
  `
-
-// runCmd represents the run command.
-var summaryCmd = &cobra.Command{
-	Use:   "summary",
-	Short: "summarize the output of model(s)",
-	Long:  summaryLongDescription,
-	Run:   summary,
-}
-
 type jsonResults struct {
 	Results []parser.SummaryOutput
 	Errors  []error
@@ -162,11 +153,19 @@ func summary(_ *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 }
-func init() {
-	nonmemCmd.AddCommand(summaryCmd)
+
+func NewSummaryCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "summarize the output of model(s)",
+		Long:  summaryLongDescription,
+		Run:   summary,
+	}
+
 	// Used for Summary
-	summaryCmd.PersistentFlags().BoolVar(&noExt, "no-ext-file", false, "do not use ext file")
-	summaryCmd.PersistentFlags().BoolVar(&noGrd, "no-grd-file", false, "do not use grd file")
-	summaryCmd.PersistentFlags().BoolVar(&noShk, "no-shk-file", false, "do not use shk file")
-	summaryCmd.PersistentFlags().StringVar(&extFile, "ext-file", "", "name of custom ext-file")
+	cmd.PersistentFlags().BoolVar(&noExt, "no-ext-file", false, "do not use ext file")
+	cmd.PersistentFlags().BoolVar(&noGrd, "no-grd-file", false, "do not use grd file")
+	cmd.PersistentFlags().BoolVar(&noShk, "no-shk-file", false, "do not use shk file")
+	cmd.PersistentFlags().StringVar(&extFile, "ext-file", "", "name of custom ext-file")
+	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,20 +21,19 @@ import (
 )
 
 // runCmd represents the run command.
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "check version",
-	Long: `check the current bbi version
-bbi version 
+func NewVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "check version",
+		Long: `check the current bbi version
+bbi version
  `,
-	Run: version,
+		Run: version,
+	}
 }
 
 func version(cmd *cobra.Command, args []string) {
 	fmt.Println(buildVersionString(VERSION))
-}
-func init() {
-	RootCmd.AddCommand(versionCmd)
 }
 
 func buildVersionString(version string) string {


### PR DESCRIPTION
Working from Eli's "Converting cobra style to testable components"
writeup, convert all `var XCmd = &cobra.Command` cases to avoid
`init()` and instead use `NewXcmd()`.  All the changes in root.go
except for the new `AddCommand()` calls are the result of applying
Eli's patch from the writeup.

---

I've done scattered testing of the executable and things seem wired up correctly.

```
$ bbi version
develop-2021-09-08T18:16:40-0400

$ head bbi.yaml
head: cannot open 'bbi.yaml' for reading: No such file or directory
$ bbi init
$ head -2 bbi.yaml
bbi_binary: /Users/KyleM/go/bin/bbi
clean_lvl: 1

$ bbi nonmem summary inst/model/nonmem/basic/1/1 | head -2
LEM PK model 1 cmt base
Dataset: ../../../../extdata/acop.csv

$ touch 1.mod
$ bbi nonmem clean *.mod
$ ls 1.mod
ls: cannot access '1.mod': No such file or director
```

---

~Note: This PR has gh-230 as its base, so it should be merged after that.~ 