### PR TITLE
Adding stories.yaml and requirements.yaml to repo

### DIFF
--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -1,0 +1,358 @@
+CFG-R001:
+  description: BBI config JSON gets created
+  tests:
+  - INT-CFG-001
+CFG-R002:
+  description: Config values are correct in written file
+  tests:
+  - INT-CFG-002
+COVCOR-R001:
+  description: CovCor parses .cov and .cor files
+  tests:
+  - INT-COVCOR-001
+COVCOR-R002:
+  description: CovCor errors with bad input
+  tests:
+  - INT-COVCOR-002
+DATA-R001:
+  description: Has valid data path for CTL
+  tests:
+  - INT-DATA-001
+DATA-R002:
+  description: Fails with invalid data path
+  tests:
+  - INT-DATA-002
+DATA-R003:
+  description: Has valid complex path CTL And Mod
+  tests:
+  - INT-DATA-003
+EXP-R001:
+  description: BBI expands without prefix
+  tests:
+  - INT-EXP-001
+EXP-R002:
+  description: BBI expands with prefix
+  tests:
+  - INT-EXP-002
+EXP-R003:
+  description: BBI expands with prefix to partial match
+  tests:
+  - INT-EXP-003
+INIT-R001:
+  description: BBI can initialize
+  tests:
+  - INT-INIT-001
+LOCAL-R001:
+  description: BBI completes local execution
+  tests:
+  - INT-LOCAL-001
+LOCAL-R002:
+  description: NMFE options end in script
+  tests:
+  - INT-LOCAL-002
+LOCAL-R003:
+  description: BBI can execute in parallel
+  tests:
+  - INT-LOCAL-003
+LOCAL-R004:
+  description: BBI loads default config
+  tests:
+  - INT-LOCAL-004
+LOCAL-R005:
+  description: BBI loads config specified by absolute path
+  tests:
+  - INT-LOCAL-005
+LOCAL-R006:
+  description: BBI loads config specified by relative path
+  tests:
+  - INT-LOCAL-006
+NMQ-R001:
+  description: NMQUAL execution succeeds
+  tests:
+  - INT-NMQ-001
+NMQ-R002:
+  description: Hashing for NMQual works with original Mod file
+  tests:
+  - INT-NMQ-002
+PARAM-R001:
+  description: Parse params for single model
+  tests:
+  - INT-PARAM-001
+PARAM-R002:
+  description: Parse params for directory of models
+  tests:
+  - INT-PARAM-002
+POSTEX-R001:
+  description: KVP expansion works
+  tests:
+  - INT-POSTEX-001
+POSTEX-R002:
+  description: Post execution succeeds
+  tests:
+  - INT-POSTEX-002
+SGE-R001:
+  description: BbiCompletesSGEExecution
+  tests:
+  - INT-SGE-001
+SGE-R002:
+  description: BBBI completes parallel SGE execution
+  tests:
+  - INT-SGE-002
+SUM-R001:
+  description: BBI summary works with default settings
+  tests:
+  - INT-SUM-001
+SUM-R002:
+  description: BBI summary arguments work
+  tests:
+  - INT-SUM-002
+SUM-R003:
+  description: BBI summary fails with bad input
+  tests:
+  - INT-SUM-003
+SUM-R004:
+  description: BBI summary works with no extension
+  tests:
+  - INT-SUM-004
+CMD-R001:
+  description: Directory contains output files
+  tests:
+  - UNIT-CMD-001
+CMD-R002:
+  description: Process NMFE options
+  tests:
+  - UNIT-CMD-002
+CMD-R003:
+  description: Model data file
+  tests:
+  - UNIT-CMD-003
+CMD-R004:
+  description: Data file is present
+  tests:
+  - UNIT-CMD-004
+CMD-R005:
+  description: SGE Job Name
+  tests:
+  - UNIT-CMD-005
+NMP-R001:
+  description: Set missing values to default parameter data method
+  tests:
+  - UNIT-NMP-001
+NMP-R002:
+  description: Set missing values to default parameter data StdErrDimension
+  tests:
+  - UNIT-NMP-002
+NMP-R003:
+  description: Set missing values to default parameter data RESDDimension/3_omegas
+  tests:
+  - UNIT-NMP-003
+NMP-R004:
+  description: Set missing values to default parameter data values
+  tests:
+  - UNIT-NMP-004
+NMP-R005:
+  description: Set missing values to default parameter name values
+  tests:
+  - UNIT-NMP-005
+NMP-R006:
+  description: Create diagonal block
+  tests:
+  - UNIT-NMP-006
+NMP-R007:
+  description: Parse Block Results
+  tests:
+  - UNIT-NMP-007
+NMP-R008:
+  description: Parse Parameter Block
+  tests:
+  - UNIT-NMP-008
+NMP-R009:
+  description: Formatting Theta Block
+  tests:
+  - UNIT-NMP-009
+NMP-R010:
+  description: Parse Theta Results Block
+  tests:
+  - UNIT-NMP-010
+NMP-R011:
+  description: Default Parameter Names
+  tests:
+  - UNIT-NMP-011
+NMP-R012:
+  description: Read Parse Cov Lines
+  tests:
+  - UNIT-NMP-012
+NMP-R013:
+  description: Path level is parsed correctly
+  tests:
+  - UNIT-NMP-013
+NMP-R014:
+  description: Omega block is parsed correctly
+  tests:
+  - UNIT-NMP-014
+NMP-R015:
+  description: Parse Parameter Structure
+  tests:
+  - UNIT-NMP-015
+NMP-R016:
+  description: Parse Parameter Structures
+  tests:
+  - UNIT-NMP-016
+NMP-R017:
+  description: Parse Final Parameter Estimates From Lst
+  tests:
+  - UNIT-NMP-017
+NMP-R018:
+  description: Read Ext
+  tests:
+  - UNIT-NMP-018
+NMP-R019:
+  description: Parse OBJV
+  tests:
+  - UNIT-NMP-019
+NMP-R020:
+  description: Par Test Parse OBJV2
+  tests:
+  - UNIT-NMP-020
+NMP-R021:
+  description: Par Test Parse OBJV3
+  tests:
+  - UNIT-NMP-021
+NMP-R022:
+  description: Parse Gradient
+  tests:
+  - UNIT-NMP-022
+NMP-R023:
+  description: Parse Condition Number
+  tests:
+  - UNIT-NMP-023
+NMP-R024:
+  description: Set Correlations Ok
+  tests:
+  - UNIT-NMP-024
+NMP-R025:
+  description: Check Matrix
+  tests:
+  - UNIT-NMP-025
+NMP-R026:
+  description: Set Cov
+  tests:
+  - UNIT-NMP-026
+NMP-R027:
+  description: Get Gradient Line
+  tests:
+  - UNIT-NMP-027
+NMP-R028:
+  description: Cleaning Theta Block
+  tests:
+  - UNIT-NMP-028
+NMP-R029:
+  description: Read Parse Shk Lines
+  tests:
+  - UNIT-NMP-029
+NMP-R030:
+  description: Read Parse Shk Lines
+  tests:
+  - UNIT-NMP-030
+NMP-R031:
+  description: GetDiagonalIndices
+  tests:
+  - UNIT-NMP-031
+NMP-R032:
+  description: Get Diagonal Indices 2
+  tests:
+  - UNIT-NMP-032
+NMP-R033:
+  description: Get Block Parameter Names
+  tests:
+  - UNIT-NMP-033
+NMP-R034:
+  description: Read Parse Grd Lines
+  tests:
+  - UNIT-NMP-034
+NMP-R035:
+  description: Parse Run Details
+  tests:
+  - UNIT-NMP-035
+NMP-R036:
+  description: Parse Estimates From Ext
+  tests:
+  - UNIT-NMP-036
+PARAM-R003:
+  description: Split Param
+  tests:
+  - UNIT-PARAM-001
+PARAM-R004:
+  description: Sort Param
+  tests:
+  - UNIT-PARAM-002
+RUN-R001:
+  description: Est Output Files By Run
+  tests:
+  - UNIT-RUN-001
+RUN-R002:
+  description: Prepare For Execution
+  tests:
+  - UNIT-RUN-002
+RUN-R003:
+  description: Default Estimate Model
+  tests:
+  - UNIT-RUN-003
+RUN-R004:
+  description: Custom Estimate Model
+  tests:
+  - UNIT-RUN-004
+RUN-R005:
+  description: Logicless Template For Estimate Model
+  tests:
+  - UNIT-RUN-005
+RUN-R006:
+  description: Read Copied Files
+  tests:
+  - UNIT-RUN-006
+RUN-R007:
+  description: Get Copied Filenames
+  tests:
+  - UNIT-RUN-007
+UTL-R001:
+  description: Dir Exists confirms directory is present
+  tests:
+  - UNIT-UTL-001
+UTL-R002:
+  description: Is Dir confirms in a directory
+  tests:
+  - UNIT-UTL-002
+UTL-R003:
+  description: File And Ext build file path
+  tests:
+  - UNIT-UTL-003
+UTL-R004:
+  description: List Matches By Regex
+  tests:
+  - UNIT-UTL-004
+UTL-R005:
+  description: List Matches By Glob
+  tests:
+  - UNIT-UTL-005
+UTL-R006:
+  description: List Model Files
+  tests:
+  - UNIT-UTL-006
+UTL-R007:
+  description: Expand Sequence converts sequence to array of numbers
+  tests:
+  - UNIT-UTL-007
+UTL-R008:
+  description: Read Params And Output From Ext
+  tests:
+  - UNIT-UTL-008
+UTL-R009:
+  description: Has Zero confirms a zero
+  tests:
+  - UNIT-UTL-009
+UTL-R010:
+  description: Pad Num pads number with values
+  tests:
+  - UNIT-UTL-010
+
+

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -91,11 +91,11 @@ POSTEX-R002:
   tests:
   - INT-POSTEX-002
 SGE-R001:
-  description: BbiCompletesSGEExecution
+  description: BBI completes SGE execution
   tests:
   - INT-SGE-001
 SGE-R002:
-  description: BBBI completes parallel SGE execution
+  description: BBI completes parallel SGE execution
   tests:
   - INT-SGE-002
 SUM-R001:

--- a/validation/stories.yaml
+++ b/validation/stories.yaml
@@ -1,0 +1,86 @@
+BBI-RUN-001:
+  name: Run NonMem jobs locally
+  description: As a user, I would like to be able to execute NonMem jobs locally,
+    without needing the grid, if NonMem is installed on the system.
+  ProductRisk: High
+  requirements:
+  - LOCAL-R001
+  - LOCAL-R003
+BBI-RUN-002:
+  name: Run NonMem jobs on the Grid
+  description: As a user, I would like to be able to submit NonMem jobs to be run
+    on a worker node in the SGE grid.
+  ProductRisk: High
+  requirements:
+  - SGE-R001
+  - SGE-R002
+BBI-RUN-003:
+  name: Notify about issues with the data referenced in the control stream
+  description: As a user, I would like to be notified, and have model execution stop,
+    if I target a NonMem control stream with bbi, but the data file referenced therein
+    cannot be located.
+  ProductRisk: Low
+  requirements:
+  - DATA-R001
+  - DATA-R002
+  - DATA-R003
+BBI-RUN-004:
+  name: Pass NMFE options directly to NonMem
+  description: As a user, I would like to be able to pass some specified options,
+    such as license or compilation options, directly to NonMem, such that they are
+    expressed in the final NMFE call.
+  ProductRisk: Low
+  requirements: LOCAL-R002
+BBI-RUN-005:
+  name: NonMem Execution via NMQual
+  description: As a user, I would like to have the option to execute NonMem the same
+    way that autolog.pl did so that NMQual can be used. I would like an option exposed
+    that will trigger bbi to specify autolog.pl syntax in its executable script, rather
+    than the typical calls directly to NMFE.
+  ProductRisk: Low
+  requirements: NMQ-R001
+BBI-RUN-006:
+  name: Capture all configurations and write to a file
+  description: As a user, I would like to have all configurations used for each run
+    captured in files that can be stored in version control, for the sake of reproducibility.
+    The files should contain the merged configurations between any flags provided,
+    configuration files and default values to indicate exactly how the model was executed.
+  ProductRisk: High
+  requirements: CFG-R001
+BBI-CFG-001:
+  name: Initialize a project with minimum configs required for execution
+  description: As a user, I would like to be able to initialize a project with bbi
+    without building the config `bbi.yaml` file from scratch. Allowing a command to
+    create this file with the minimum default configuration necessary.
+  ProductRisk: Medium
+  requirements: INIT-R001
+BBI-SUM-001:
+  name: Parse model output folder
+  description: As a user, I want to be able to parse a summary of the files in the
+    NonMem output folder into either a human-readable table, or a machine-readable
+    structure like `.json`.
+  ProductRisk: Medium
+  requirements:
+  - SUM-R001
+  - SUM-R002
+  - SUM-R003
+  - SUM-R004
+BBI-COV-001:
+  name: Parse .cov and .cor files
+  description: As a user, I want to be able to parse the `.cov` and `.cor` files in
+    the NonMem output folder into a machine-readable structure like `.json`.
+  ProductRisk: Low
+  requirements:
+  - COVCOR-R001
+  - COVCOR-R002
+BBI-SUM-002:
+  name: Parse batch parameter estimates
+  description: As a user, I would like to be able to parse the final parameter estimates
+    from multiple NONMEM model output directories as a batch.
+  ProductRisk: Low
+  requirements:
+  - PARAM-R001
+  - PARAM-R002
+  - NMP-R036
+  - PARAM-R001
+  - PARAM-R002


### PR DESCRIPTION
Moving validation stories and requirements into YAML files in the repo, as opposed to external Googlesheets.

Below is some sample R code to generate validation docs from these YAML files (and test results that are dumped to S3 from our drone CI). The intention is to add something like this as another step in the CI that will generate the docs and dump them to S3 anytime a tag is pushed.

```r
library(mrgvalprep)
library(mrgvalidate)

# set working dir to the validation/ dir in the BBI repo, then
# copy the results.json and summary.json from a drone run into this directory
test_dir <- "test_output"

# parse raw Go test results and write to csv
test_res <- parse_golang_test_json(file.path(test_dir, "results.json"))
readr::write_csv(test_res, file.path(test_dir, "summary.csv"))

# read in spec YAML files
spec <- read_spec_yaml(
  "stories.yaml",
  "requirements.yaml"
)

create_validation_docs(
  "bbi",
  "3.1.1.9000",
  spec,
  auto_test_dir = test_dir,
)
```