### PR TITLE
README.md: update .drone.yml link

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,5 +1,5 @@
 # bbitest
-This directory contains integration tests data. Many of these tests must be run in an environment containing a working NONMEM installation and/or worker nodes that can be used to execute jobs. See [the `.drone.yml` in `bbi`](https://github.com/metrumresearchgroup/bbi/blob/develop/.drone.yml) for examples.
+This directory contains integration tests data. Many of these tests must be run in an environment containing a working NONMEM installation and/or worker nodes that can be used to execute jobs. See [`.drone.yml`](/.drone.yml) for examples.
 
 ## Refreshing golden files
 The `bbi nonmem summary` tests (in `integration/bbi_summary_test.go`) use golden files stored in `integration/testdata/bbi_summary/aa_golden_files/`. These need to be refreshed when the relevant functionality in `bbi` changes. This can be done by running the tests with the `UPDATE_SUMMARY=true` environment variable, like so:


### PR DESCRIPTION
integration/README.md links to
https://github.com/metrumresearchgroup/bbi/blob/develop/.drone.yml

That "develop" part needs to be updated because we're going to remove
the `develop` branch and start using `main` as the base for topic
branches.  But using the full URL here is a holdover from when this
file was in the bbitest repo prior to 6efbe54 (Merge bbitest #242,
2021-09-21).  Switch to using a relative link.