### PR TITLE
validation: add SUM-R005 to stories.yaml

### DIFF
--- a/validation/stories.yaml
+++ b/validation/stories.yaml
@@ -65,6 +65,7 @@ BBI-SUM-001:
   - SUM-R002
   - SUM-R003
   - SUM-R004
+  - SUM-R005
 BBI-COV-001:
   name: Parse .cov and .cor files
   description: As a user, I want to be able to parse the `.cov` and `.cor` files in


### PR DESCRIPTION
f010897 (nmparser: support multiple values for estimation and
covariance time, 2022-07-06) added the SUM-R005 requirement but didn't
wire it up to a story.