### PR TITLE
reclean: avoid index error if no positional argument is specified

### DIFF
--- a/cmd/reclean.go
+++ b/cmd/reclean.go
@@ -43,7 +43,7 @@ func reclean(cmd *cobra.Command, args []string) error {
 
 func NewRecleanCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "reclean",
+		Use:   "reclean [flags] <directory>",
 		Short: "clean files in an estimation directory by clean level",
 		Long: `
 	bbi reclean run001_est_01

--- a/cmd/reclean.go
+++ b/cmd/reclean.go
@@ -28,6 +28,10 @@ func reclean(cmd *cobra.Command, args []string) error {
 	if debug {
 		viper.Debug()
 	}
+	if len(args) != 1 {
+		return fmt.Errorf("must specify one positional argument, a directory")
+	}
+
 	AppFs := afero.NewOsFs()
 	err := runner.CleanEstFolder(AppFs, args[0], []string{}, viper.GetInt("clean_lvl"), verbose, debug, preview)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,6 @@ func Execute(build string) {
 	cmd := NewRootCmd()
 	cmd.Long = fmt.Sprintf("bbi cli version %s", VERSION)
 	if err := cmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(-1)
 	}
 }

--- a/integration/bbi_reclean_test.go
+++ b/integration/bbi_reclean_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -22,4 +23,17 @@ func TestBBIRecleanBasic(tt *testing.T) {
 	t.R.NoError(err)
 	t.R.NotEmpty(output)
 	t.A.NoFileExists(fdata)
+}
+
+func TestBBIRecleanError(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+
+	output, err := executeCommandNoErrorCheck(context.Background(),
+		"bbi", "nonmem", "reclean")
+
+	t.R.NotNil(err)
+	errorMatch, _ := regexp.MatchString("one positional", output)
+	t.R.True(errorMatch)
+	errorMatch, _ = regexp.MatchString("Usage", output)
+	t.R.True(errorMatch)
 }

--- a/integration/bbi_reclean_test.go
+++ b/integration/bbi_reclean_test.go
@@ -1,0 +1,25 @@
+package bbitest
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/metrumresearchgroup/wrapt"
+)
+
+func TestBBIRecleanBasic(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+
+	dir := t.TempDir()
+	fdata := filepath.Join(dir, "FDATA")
+	_ = ioutil.WriteFile(fdata, []byte("fake"), 0644)
+	t.A.FileExists(fdata)
+
+	output, err := executeCommand(context.Background(),
+		"bbi", "nonmem", "reclean", "--recleanLvl=1", "-v", dir)
+	t.R.NoError(err)
+	t.R.NotEmpty(output)
+	t.A.NoFileExists(fdata)
+}


### PR DESCRIPTION
This small PR fixes the following error that I noticed when looking into another issue:

```
$ bbi nonmem reclean
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
[...]
```

With this PR, that becomes

```
$ bbi nonmem reclean
Error: must specify one positional argument, a directory
Usage:
  bbi nonmem reclean [flags] <directory>

Flags:
[...]
```

It also fixes the more general issue of bbi double printing errors messages for `RunE` commands (mentioned in https://github.com/metrumresearchgroup/bbi/pull/272#discussion_r932278348)

Note that this PR uses gh-272 as the base, so this shouldn't be merged before that PR.  That was done just to piggyback off of its last commit (e1e1bda) that quiets the linter (the tests from the PR trigger the same issue independently).
