### PR TITLE
drone: update to latest golangci-lint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ steps:
   - name: lint
     image: golang:1.17
     commands:
-      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.1
+      - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.47.2
       - golangci-lint run
 ---
 kind: pipeline

--- a/parsers/nmparser/parse_run_details.go
+++ b/parsers/nmparser/parse_run_details.go
@@ -37,8 +37,7 @@ func replaceTrim(line string, replacement string) string {
 } */
 
 func parseLine(line string, n int) string {
-	tokens := strings.Fields(line)
-	if len(tokens) >= n {
+	if tokens := strings.Fields(line); len(tokens) >= n {
 		return tokens[n]
 	}
 


### PR DESCRIPTION
Drone's lint phase is passing with no warnings, but the latest version
of golangci-lint (which I have installed locally) shows a "variable
'tokens' is only used in the if-statement" warning.  Catch drone up
with the latest release so that its results are more likely to align
with what developers see locally.