### PR TITLE
nonmem: pass -maxlim=2 to nmfe by default

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -227,8 +227,8 @@ func NewNonmemCmd() *cobra.Command {
 	errpanic(viper.BindPFlag(nmfeGroup+"."+noBuildIdentifier, cmd.PersistentFlags().Lookup(noBuildIdentifier)))
 
 	const maxLimIdentifier string = "maxlim"
-	cmd.PersistentFlags().Int(maxLimIdentifier, 100,
-		"RAW NMFE OPTION - Set the maximum values for the buffers used by Nonmem")
+	cmd.PersistentFlags().Int(maxLimIdentifier, 2,
+		"RAW NMFE OPTION - Set the maximum values for the buffers used by Nonmem (if 0, don't pass -maxlim to nmfe)")
 	errpanic(viper.BindPFlag(nmfeGroup+"."+maxLimIdentifier, cmd.PersistentFlags().Lookup(maxLimIdentifier)))
 
 	cmd.AddCommand(NewCleanCmd())
@@ -1017,10 +1017,11 @@ func processNMFEOptions(config configlib.Config) []string {
 		output = append(output, "-nobuild")
 	}
 
-	// Valid values are 1 through 3.  Defaults to 100.
+	// Valid values are 1 through 3.  Defaults to 2.
 	//
 	// 100 and 0 are treated as special values that indicate to _not_
-	// pass -maxlim.
+	// pass -maxlim.  0 is the advertised way, and 100 is kept around
+	// for compatibility because it used to be the default value.
 	if config.NMFEOptions.MaxLim > 0 && config.NMFEOptions.MaxLim < 4 {
 		output = append(output, "-maxlim="+strconv.Itoa(config.NMFEOptions.MaxLim))
 	} else if !(config.NMFEOptions.MaxLim == 0 || config.NMFEOptions.MaxLim == 100) {

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -227,7 +227,8 @@ func NewNonmemCmd() *cobra.Command {
 	errpanic(viper.BindPFlag(nmfeGroup+"."+noBuildIdentifier, cmd.PersistentFlags().Lookup(noBuildIdentifier)))
 
 	const maxLimIdentifier string = "maxlim"
-	cmd.PersistentFlags().Int(maxLimIdentifier, 100, "RAW NMFE OPTION - Set the maximum values set for the buffers used by Nonmem")
+	cmd.PersistentFlags().Int(maxLimIdentifier, 100,
+		"RAW NMFE OPTION - Set the maximum values for the buffers used by Nonmem")
 	errpanic(viper.BindPFlag(nmfeGroup+"."+maxLimIdentifier, cmd.PersistentFlags().Lookup(maxLimIdentifier)))
 
 	cmd.AddCommand(NewCleanCmd())

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -1018,11 +1018,11 @@ func processNMFEOptions(config configlib.Config) []string {
 
 	// Valid values are 1 through 3.  Defaults to 100.
 	//
-	// 100 is treated as a special value that indicates to _not_ pass
-	// -maxlim.
+	// 100 and 0 are treated as special values that indicate to _not_
+	// pass -maxlim.
 	if config.NMFEOptions.MaxLim > 0 && config.NMFEOptions.MaxLim < 4 {
 		output = append(output, "-maxlim="+strconv.Itoa(config.NMFEOptions.MaxLim))
-	} else if config.NMFEOptions.MaxLim != 100 {
+	} else if !(config.NMFEOptions.MaxLim == 0 || config.NMFEOptions.MaxLim == 100) {
 		log.Warnf("ignoring invalid maxlim value: %v", config.NMFEOptions.MaxLim)
 	}
 

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -1016,9 +1016,14 @@ func processNMFEOptions(config configlib.Config) []string {
 		output = append(output, "-nobuild")
 	}
 
-	// Only goes to 3, defaults to 100. Just a quick way to check for "empty" setting
-	if config.NMFEOptions.MaxLim < 50 {
+	// Valid values are 1 through 3.  Defaults to 100.
+	//
+	// 100 is treated as a special value that indicates to _not_ pass
+	// -maxlim.
+	if config.NMFEOptions.MaxLim > 0 && config.NMFEOptions.MaxLim < 4 {
 		output = append(output, "-maxlim="+strconv.Itoa(config.NMFEOptions.MaxLim))
+	} else if config.NMFEOptions.MaxLim != 100 {
+		log.Warnf("ignoring invalid maxlim value: %v", config.NMFEOptions.MaxLim)
 	}
 
 	return output

--- a/cmd/nonmem_test.go
+++ b/cmd/nonmem_test.go
@@ -167,6 +167,17 @@ func Test_processNMFEOptions(tt *testing.T) {
 			want: nil,
 		},
 		{
+			name: "maxlim=2",
+			args: args{
+				config: configlib.Config{
+					NMFEOptions: configlib.NMFEOptions{
+						MaxLim: 2,
+					},
+				},
+			},
+			want: []string{"-maxlim=2"},
+		},
+		{
 			name: "maxlim=0",
 			args: args{
 				config: configlib.Config{

--- a/cmd/nonmem_test.go
+++ b/cmd/nonmem_test.go
@@ -166,6 +166,17 @@ func Test_processNMFEOptions(tt *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name: "maxlim=0",
+			args: args{
+				config: configlib.Config{
+					NMFEOptions: configlib.NMFEOptions{
+						MaxLim: 0,
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 	testId := "UNIT-CMD-002"
 	for _, test := range tests {

--- a/cmd/nonmem_test.go
+++ b/cmd/nonmem_test.go
@@ -155,6 +155,17 @@ func Test_processNMFEOptions(tt *testing.T) {
 				"-prcompile",
 			},
 		},
+		{
+			name: "invalid maxlim",
+			args: args{
+				config: configlib.Config{
+					NMFEOptions: configlib.NMFEOptions{
+						MaxLim: -1,
+					},
+				},
+			},
+			want: nil,
+		},
 	}
 	testId := "UNIT-CMD-002"
 	for _, test := range tests {

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -67,7 +67,7 @@ type NMFEOptions struct {
 	PRDefault   bool   `mapstructure:"prdefault" yaml:"prdefault" json:"prdefault,omitempty"`
 	TPRDefault  bool   `mapstructure:"tprdefault" yaml:"tprdefault" json:"tprdefault,omitempty"`
 	NoBuild     bool   `mapstructure:"nobuild" yaml:"nobuild" json:"nobuild,omitempty"`
-	MaxLim      int    `mapstructure:"maxlim" yaml:"maxlim" json:"maxlim,omitempty"` // Default (empty value) is 3
+	MaxLim      int    `mapstructure:"maxlim" yaml:"maxlim" json:"maxlim,omitempty"`
 }
 
 func (c Config) RenderYamlToFile(path string) error {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -50,6 +50,7 @@ func TestInitialization(tt *testing.T) {
 				t.R.NoError(yaml.Unmarshal(bytes, &c))
 
 				t.A.Greater(len(c.Nonmem), 0)
+				t.A.Equal(100, c.NMFEOptions.MaxLim)
 			})
 		})
 	}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -50,7 +50,7 @@ func TestInitialization(tt *testing.T) {
 				t.R.NoError(yaml.Unmarshal(bytes, &c))
 
 				t.A.Greater(len(c.Nonmem), 0)
-				t.A.Equal(100, c.NMFEOptions.MaxLim)
+				t.A.Equal(2, c.NMFEOptions.MaxLim)
 			})
 		})
 	}

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -148,6 +148,11 @@ CMD-R005:
   description: SGE Job Name
   tests:
   - UNIT-CMD-005
+CMD-R006:
+  description: Pass -maxeval=2 to NMFE by default
+  tests:
+  - INT-INIT-001
+  - UNIT-CMD-002
 NMP-R001:
   description: Set missing values to default parameter data method
   tests:

--- a/validation/stories.yaml
+++ b/validation/stories.yaml
@@ -30,7 +30,9 @@ BBI-RUN-004:
     such as license or compilation options, directly to NonMem, such that they are
     expressed in the final NMFE call.
   ProductRisk: Low
-  requirements: LOCAL-R002
+  requirements:
+  - CMD-R002
+  - LOCAL-R002
 BBI-RUN-005:
   name: NonMem Execution via NMQual
   description: As a user, I would like to have the option to execute NonMem the same

--- a/validation/stories.yaml
+++ b/validation/stories.yaml
@@ -32,6 +32,7 @@ BBI-RUN-004:
   ProductRisk: Low
   requirements:
   - CMD-R002
+  - CMD-R006
   - LOCAL-R002
 BBI-RUN-005:
   name: NonMem Execution via NMQual


### PR DESCRIPTION
This PR makes it so that `-maxlim=2` is passed to `nmfe` by default, following @kylebaron's recommendation.

Closes #262.
