### PR TITLE
nonmem: expose PRDefault and TPRDefault as command line options

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -222,6 +222,14 @@ func NewNonmemCmd() *cobra.Command {
 	cmd.PersistentFlags().Bool(prCompileIdentifier, false, "RAW NMFE OPTION - Forces PREDPP compilation")
 	errpanic(viper.BindPFlag(nmfeGroup+"."+prCompileIdentifier, cmd.PersistentFlags().Lookup(prCompileIdentifier)))
 
+	const prDefaultIdentifier string = "prdefault"
+	cmd.PersistentFlags().Bool(prDefaultIdentifier, false, "RAW NMFE OPTION - Do not recompile any routines other than FSUBS")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+prDefaultIdentifier, cmd.PersistentFlags().Lookup(prDefaultIdentifier)))
+
+	const tprDefaultIdentifier string = "tprdefault"
+	cmd.PersistentFlags().Bool(tprDefaultIdentifier, false, "RAW NMFE OPTION - Test if is okay to do -prdefault")
+	errpanic(viper.BindPFlag(nmfeGroup+"."+tprDefaultIdentifier, cmd.PersistentFlags().Lookup(tprDefaultIdentifier)))
+
 	const noBuildIdentifier string = "nobuild"
 	cmd.PersistentFlags().Bool(noBuildIdentifier, false, "RAW NMFE OPTION - Skips recompiling and rebuilding on nonmem executable")
 	errpanic(viper.BindPFlag(nmfeGroup+"."+noBuildIdentifier, cmd.PersistentFlags().Lookup(noBuildIdentifier)))


### PR DESCRIPTION
nmfe's -prdefault and -tprdefault have fields in NMFEOptions (since
ac48a49, 2020-02-16) and are considered by processNMFEOptions() (since
3583755, 2020-02-16), but they aren't exposed as command line flags.

That appears to just be an oversight.  Add corresponding --prdefault
and --tprdefault flags to `bbi nonmem`.

Re: #262
Re: #263

---

### Before

```
$ bbi nonmem run local --nm_version=nm74gf --maxlim=3 --overwrite --prdefault inst/model/nonmem/basic/1.ctl
Error: unknown flag: --prdefault
Usage:
  bbi nonmem run local [flags]
[...]
```

```
$ bbi nonmem run local --nm_version=nm74gf --maxlim=3 --overwrite --tprdefault inst/model/nonmem/basic/1.ctl
Error: unknown flag: --tprdefault
Usage:
  bbi nonmem run local [flags]
[...]
```

### After


```
$ bbi nonmem run local --nm_version=nm74gf --maxlim=3 --overwrite --tprdefault inst/model/nonmem/basic/1.ctl
$ grep tprdefault inst/model/nonmem/basic/1/1.sh
/opt/NONMEM/nm74gf/run/nmfe74 1.ctl  1.lst  -tprdefault -maxlim=3
```

```
$ bbi nonmem run local --nm_version=nm74gf --maxlim=3 --overwrite --prdefault inst/model/nonmem/basic/1.ctl
$ grep prdefault inst/model/nonmem/basic/1/1.sh
/opt/NONMEM/nm74gf/run/nmfe74 1.ctl  1.lst  -prdefault -maxlim=3
```


```
$ bbi nonmem run local --debug --nm_version=nm74gf --maxlim=3 --overwrite --prdefault --tprdefault inst/model/nonmem/basic/1.ctl
[...]
FATA[0000] tprdefault and prdefault cannot be both set
```
