### PR TITLE
nmparser: handle $PROBLEM in addition to $PROB

### DIFF
--- a/integration/testdata/bbi_summary/aa_golden_files/12.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/12.golden.json
@@ -10,7 +10,7 @@
 		"cpu_time": 0,
 		"function_evaluations": 665,
 		"significant_digits": 3.8,
-		"problem_text": "LEM BS-12 106-104 + COV-effects(CRCL, AGE) on CL",
+		"problem_text": "BS-12 106-104 + COV-effects(CRCL, AGE) on CL",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/12.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/12.golden.txt
@@ -1,4 +1,4 @@
-LEM BS-12 106-104 + COV-effects(CRCL, AGE) on CL
+BS-12 106-104 + COV-effects(CRCL, AGE) on CL
 Dataset: ../data/12.csv
 Records: 4319   Observations: 3158  Subjects: 160
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/66.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/66.golden.json
@@ -10,7 +10,7 @@
 		"cpu_time": 4.679,
 		"function_evaluations": -999999999,
 		"significant_digits": -999999999,
-		"problem_text": "LEM BS-66 106-104 + COV-effects(CRCL, AGE) on CL",
+		"problem_text": "BS-66 106-104 + COV-effects(CRCL, AGE) on CL",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/66.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/66.golden.txt
@@ -1,4 +1,4 @@
-LEM BS-66 106-104 + COV-effects(CRCL, AGE) on CL
+BS-66 106-104 + COV-effects(CRCL, AGE) on CL
 Dataset: ../data/66.csv
 Records: 4359   Observations: 3176  Subjects: 160
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/acop-iov.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop-iov.golden.json
@@ -13,7 +13,7 @@
 		"cpu_time": 14595.976,
 		"function_evaluations": 457,
 		"significant_digits": 3.1,
-		"problem_text": "LEM PK model 1 cmt base with IOV on CL",
+		"problem_text": "PK model 1 cmt base with IOV on CL",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/acop-iov.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop-iov.golden.txt
@@ -1,4 +1,4 @@
-LEM PK model 1 cmt base with IOV on CL
+PK model 1 cmt base with IOV on CL
 Dataset: ../acop_iov.csv
 Records: 7566   Observations: 6396  Subjects: 39
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/acop-nan.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop-nan.golden.json
@@ -13,7 +13,7 @@
 		"cpu_time": 2.543,
 		"function_evaluations": 366,
 		"significant_digits": 3.2,
-		"problem_text": "LEM PK model 1 cmt base",
+		"problem_text": "PK model 1 cmt base",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/acop-nan.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop-nan.golden.txt
@@ -1,4 +1,4 @@
-LEM PK model 1 cmt base
+PK model 1 cmt base
 Dataset: ../../data/acop.csv
 Records: 799   Observations: 760  Subjects: 40
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/acop.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop.golden.json
@@ -13,7 +13,7 @@
 		"cpu_time": 2.543,
 		"function_evaluations": 366,
 		"significant_digits": 3.2,
-		"problem_text": "LEM PK model 1 cmt base",
+		"problem_text": "PK model 1 cmt base",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/acop.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop.golden.txt
@@ -1,4 +1,4 @@
-LEM PK model 1 cmt base
+PK model 1 cmt base
 Dataset: ../../data/acop.csv
 Records: 799   Observations: 760  Subjects: 40
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/acop_no_grd.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop_no_grd.golden.json
@@ -13,7 +13,7 @@
 		"cpu_time": 2.543,
 		"function_evaluations": 366,
 		"significant_digits": 3.2,
-		"problem_text": "LEM PK model 1 cmt base",
+		"problem_text": "PK model 1 cmt base",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation with Interaction"

--- a/integration/testdata/bbi_summary/aa_golden_files/acop_no_grd.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/acop_no_grd.golden.txt
@@ -1,4 +1,4 @@
-LEM PK model 1 cmt base
+PK model 1 cmt base
 Dataset: ../../data/acop.csv
 Records: 799   Observations: 760  Subjects: 40
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/iovmm.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/iovmm.golden.json
@@ -10,7 +10,7 @@
 		"cpu_time": 133.637,
 		"function_evaluations": 380,
 		"significant_digits": 3,
-		"problem_text": "LEM 10 mixture model and IOV on CL",
+		"problem_text": "10 mixture model and IOV on CL",
 		"mod_file": "-999999999",
 		"estimation_method": [
 			"First Order Conditional Estimation"

--- a/integration/testdata/bbi_summary/aa_golden_files/iovmm.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/iovmm.golden.txt
@@ -1,4 +1,4 @@
-LEM 10 mixture model and IOV on CL
+10 mixture model and IOV on CL
 Dataset: ../MixSim.csv
 Records: 13500   Observations: 12600  Subjects: 300
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/multiple-models-error.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/multiple-models-error.golden.json
@@ -15,7 +15,7 @@
 				"cpu_time": 2.543,
 				"function_evaluations": 366,
 				"significant_digits": 3.2,
-				"problem_text": "LEM PK model 1 cmt base",
+				"problem_text": "PK model 1 cmt base",
 				"mod_file": "-999999999",
 				"estimation_method": [
 					"First Order Conditional Estimation with Interaction"
@@ -252,7 +252,7 @@
 				"cpu_time": 133.637,
 				"function_evaluations": 380,
 				"significant_digits": 3,
-				"problem_text": "LEM 10 mixture model and IOV on CL",
+				"problem_text": "10 mixture model and IOV on CL",
 				"mod_file": "-999999999",
 				"estimation_method": [
 					"First Order Conditional Estimation"

--- a/integration/testdata/bbi_summary/aa_golden_files/multiple-models.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/multiple-models.golden.json
@@ -15,7 +15,7 @@
 				"cpu_time": 2.543,
 				"function_evaluations": 366,
 				"significant_digits": 3.2,
-				"problem_text": "LEM PK model 1 cmt base",
+				"problem_text": "PK model 1 cmt base",
 				"mod_file": "-999999999",
 				"estimation_method": [
 					"First Order Conditional Estimation with Interaction"
@@ -210,7 +210,7 @@
 				"cpu_time": 0,
 				"function_evaluations": 665,
 				"significant_digits": 3.8,
-				"problem_text": "LEM BS-12 106-104 + COV-effects(CRCL, AGE) on CL",
+				"problem_text": "BS-12 106-104 + COV-effects(CRCL, AGE) on CL",
 				"mod_file": "-999999999",
 				"estimation_method": [
 					"First Order Conditional Estimation with Interaction"
@@ -443,7 +443,7 @@
 				"cpu_time": 133.637,
 				"function_evaluations": 380,
 				"significant_digits": 3,
-				"problem_text": "LEM 10 mixture model and IOV on CL",
+				"problem_text": "10 mixture model and IOV on CL",
 				"mod_file": "-999999999",
 				"estimation_method": [
 					"First Order Conditional Estimation"

--- a/integration/testdata/bbi_summary/aa_golden_files/multiple-models.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/multiple-models.golden.txt
@@ -1,4 +1,4 @@
-LEM PK model 1 cmt base
+PK model 1 cmt base
 Dataset: ../../data/acop.csv
 Records: 799   Observations: 760  Subjects: 40
 Estimation Method(s):
@@ -21,7 +21,7 @@ No Heuristic Problems Detected
 +------------+------+----------+---------------+
 
 
-LEM BS-12 106-104 + COV-effects(CRCL, AGE) on CL
+BS-12 106-104 + COV-effects(CRCL, AGE) on CL
 Dataset: ../data/12.csv
 Records: 4319   Observations: 3158  Subjects: 160
 Estimation Method(s):
@@ -48,7 +48,7 @@ No Heuristic Problems Detected
 +------------+------+----------+---------------+
 
 
-LEM 10 mixture model and IOV on CL
+10 mixture model and IOV on CL
 Dataset: ../MixSim.csv
 Records: 13500   Observations: 12600  Subjects: 300
 Estimation Method(s):

--- a/integration/testdata/bbi_summary/aa_golden_files/onlysim.golden.json
+++ b/integration/testdata/bbi_summary/aa_golden_files/onlysim.golden.json
@@ -7,7 +7,7 @@
 		"cpu_time": 0.022,
 		"function_evaluations": -999999999,
 		"significant_digits": -999999999,
-		"problem_text": "LEM    RUN# ecomp1_pkpd EFFECT COMP POPULATION PK-PD MODEL 1",
+		"problem_text": "RUN# ecomp1_pkpd EFFECT COMP POPULATION PK-PD MODEL 1",
 		"mod_file": "-999999999",
 		"data_set": "dat1.csv",
 		"number_of_subjects": 2,

--- a/integration/testdata/bbi_summary/aa_golden_files/onlysim.golden.txt
+++ b/integration/testdata/bbi_summary/aa_golden_files/onlysim.golden.txt
@@ -1,4 +1,4 @@
-LEM    RUN# ecomp1_pkpd EFFECT COMP POPULATION PK-PD MODEL 1
+RUN# ecomp1_pkpd EFFECT COMP POPULATION PK-PD MODEL 1
 Dataset: dat1.csv
 Records: 100   Observations: 98  Subjects: 2
 No Estimation Methods (ONLYSIM)

--- a/parsers/nmparser/parse_run_details.go
+++ b/parsers/nmparser/parse_run_details.go
@@ -20,6 +20,8 @@ func parseNMVersion(line string) string {
 	return res
 }
 
+var problemRe = regexp.MustCompile(`^\s*\$PROB(?:LEM)?\s+`)
+
 func replaceTrim(line string, replacement string) string {
 	return strings.TrimSpace(strings.Replace(line, replacement, "", -1))
 }
@@ -74,8 +76,8 @@ func ParseRunDetails(lines []string) RunDetails {
 			if i+1 < len(lines) {
 				runDetails.RunEnd = lines[i+1]
 			}
-		case strings.Contains(line, "$PROB"):
-			runDetails.ProblemText = replaceTrim(line, "$PROB")
+		case problemRe.MatchString(line):
+			runDetails.ProblemText = problemRe.ReplaceAllString(line, "")
 		case strings.Contains(line, "#METH:"):
 			runDetails.EstimationMethods = append(runDetails.EstimationMethods, replaceTrim(line, "#METH:"))
 		case strings.HasPrefix(line, "$SIM"):

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -30,6 +30,36 @@ var _ = /* RunDetails02Results */ RunDetails{
 }
 
 func TestParseRunDetails(tt *testing.T) {
+	baseInput := []string{
+		"Days until program expires : 122",
+		"1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.2.0",
+		" ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN",
+		" #TERM:",
+		"0MINIMIZATION SUCCESSFUL",
+		" NO. OF FUNCTION EVALUATIONS USED:      352",
+		" NO. OF SIG. DIGITS IN FINAL EST.:  3.4",
+		"",
+		"#TERE:",
+		"Elapsed estimation  time in seconds:     6.84",
+		"Elapsed covariance  time in seconds:     3.34",
+		"Elapsed postprocess time in seconds:     0.0",
+		"This file was created using /opt/NONMEM/nm72g/run/nmfe72",
+		"Started  Tue Dec 17 18:10:55 2013",
+		"Finished Tue Dec 17 18:11:32 2013",
+		"$PROB 3.mod, double inital estimates",
+		"",
+		"#METH: First Order Conditional Estimation with Interaction",
+		"$DATA ../../derived/mock1.csv IGNORE=C",
+		"TOT. NO. OF INDIVIDUALS:       50",
+		"TOT. NO. OF OBS RECS:      442",
+		"NO. OF DATA RECS IN DATA SET:      492",
+		"$TABLE NOPRINT ONEHEADER FILE=./1.tab",
+	}
+
+	infInput := make([]string, len(baseInput))
+	copy(infInput, baseInput)
+	infInput[21] = "TOT. NO. OF DATA RECS:      492"
+
 	RunDetails01Results := RunDetails{
 		Version:             "7.2.0",
 		RunStart:            "Tue Dec 17 18:10:55 2013",
@@ -61,64 +91,13 @@ func TestParseRunDetails(tt *testing.T) {
 		expected RunDetails
 	}{
 		{
-			name: "RunDetails01",
-			input: []string{
-				"Days until program expires : 122",
-				"1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.2.0",
-				" ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN",
-				" #TERM:",
-				"0MINIMIZATION SUCCESSFUL",
-				" NO. OF FUNCTION EVALUATIONS USED:      352",
-				" NO. OF SIG. DIGITS IN FINAL EST.:  3.4",
-				"",
-				"#TERE:",
-				"Elapsed estimation  time in seconds:     6.84",
-				"Elapsed covariance  time in seconds:     3.34",
-				"Elapsed postprocess time in seconds:     0.0",
-				"This file was created using /opt/NONMEM/nm72g/run/nmfe72",
-				"Started  Tue Dec 17 18:10:55 2013",
-				"Finished Tue Dec 17 18:11:32 2013",
-				"$PROB 3.mod, double inital estimates",
-				"",
-				"#METH: First Order Conditional Estimation with Interaction",
-				"$DATA ../../derived/mock1.csv IGNORE=C",
-				"TOT. NO. OF INDIVIDUALS:       50",
-				"TOT. NO. OF OBS RECS:      442",
-				"NO. OF DATA RECS IN DATA SET:      492",
-				"$TABLE NOPRINT ONEHEADER FILE=./1.tab",
-			},
+			name:     "RunDetails01",
+			input:    baseInput,
 			expected: RunDetails01Results,
 		},
 		{
-			name: "RunDetailsInfn",
-			input: []string{
-				"Days until program expires : 122",
-				"1NONLINEAR MIXED EFFECTS MODEL PROGRAM (NONMEM) VERSION 7.2.0",
-				" ORIGINALLY DEVELOPED BY STUART BEAL, LEWIS SHEINER, AND ALISON BOECKMANN",
-				" #TERM:",
-				"0MINIMIZATION SUCCESSFUL",
-				" NO. OF FUNCTION EVALUATIONS USED:      352",
-				" NO. OF SIG. DIGITS IN FINAL EST.:  3.4",
-				"",
-				"#TERE:",
-				"Elapsed estimation  time in seconds:     6.84",
-				"Elapsed covariance  time in seconds:     3.34",
-				"Elapsed postprocess time in seconds:     0.0",
-				"This file was created using /opt/NONMEM/nm72g/run/nmfe72",
-				"Started  Tue Dec 17 18:10:55 2013",
-				"Finished Tue Dec 17 18:11:32 2013",
-				"$PROB 3.mod, double inital estimates",
-				"",
-				"#METH: First Order Conditional Estimation with Interaction",
-				"$DATA ../../derived/mock1.csv IGNORE=C",
-				"TOT. NO. OF INDIVIDUALS:       50",
-				"TOT. NO. OF OBS RECS:      442",
-				// Difference with RunDetails01Results: Drop "NO. OF DATA RECS
-				// IN DATA SET:" line and add the one below to mimic $INFN
-				// output.
-				"TOT. NO. OF DATA RECS:      492",
-				"$TABLE NOPRINT ONEHEADER FILE=./1.tab",
-			},
+			name:     "RunDetailsInfn",
+			input:    infInput,
 			expected: RunDetails01Results,
 		},
 		{

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -79,8 +79,7 @@ func TestParseRunDetails(tt *testing.T) {
 				"Started  Tue Dec 17 18:10:55 2013",
 				"Finished Tue Dec 17 18:11:32 2013",
 				"$PROB 3.mod, double inital estimates",
-				"", // TODO, pass full path control stream file name into ParseRunDetails
-				// 3.mod; initial estimate of inter-subject variability (matrix). also ETA
+				"",
 				"#METH: First Order Conditional Estimation with Interaction",
 				"$DATA ../../derived/mock1.csv IGNORE=C",
 				"TOT. NO. OF INDIVIDUALS:       50",
@@ -109,8 +108,7 @@ func TestParseRunDetails(tt *testing.T) {
 				"Started  Tue Dec 17 18:10:55 2013",
 				"Finished Tue Dec 17 18:11:32 2013",
 				"$PROB 3.mod, double inital estimates",
-				"", // TODO, pass full path control stream file name into ParseRunDetails
-				// 3.mod; initial estimate of inter-subject variability (matrix). also ETA
+				"",
 				"#METH: First Order Conditional Estimation with Interaction",
 				"$DATA ../../derived/mock1.csv IGNORE=C",
 				"TOT. NO. OF INDIVIDUALS:       50",

--- a/parsers/nmparser/parse_run_details_test.go
+++ b/parsers/nmparser/parse_run_details_test.go
@@ -60,6 +60,10 @@ func TestParseRunDetails(tt *testing.T) {
 	copy(infInput, baseInput)
 	infInput[21] = "TOT. NO. OF DATA RECS:      492"
 
+	fullProbInput := make([]string, len(baseInput))
+	copy(fullProbInput, baseInput)
+	fullProbInput[15] = "$PROBLEM 3.mod, double inital estimates"
+
 	RunDetails01Results := RunDetails{
 		Version:             "7.2.0",
 		RunStart:            "Tue Dec 17 18:10:55 2013",
@@ -98,6 +102,11 @@ func TestParseRunDetails(tt *testing.T) {
 		{
 			name:     "RunDetailsInfn",
 			input:    infInput,
+			expected: RunDetails01Results,
+		},
+		{
+			name:     "RunDetailFullProb",
+			input:    fullProbInput,
 			expected: RunDetails01Results,
 		},
 		{

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -324,6 +324,11 @@ NMP-R036:
   description: Parse Estimates From Ext
   tests:
   - UNIT-NMP-036
+NMP-R037:
+  description: Correctly parses problem text when either short or long-form
+    keyword is used.
+  tests:
+  - UNIT-NMP-035
 PARAM-R003:
   description: Split Param
   tests:

--- a/validation/stories.yaml
+++ b/validation/stories.yaml
@@ -76,6 +76,7 @@ BBI-SUM-001:
   - SUM-R009
   - SUM-R010
   - SUM-R011
+  - NMP-R037
 BBI-COV-001:
   name: Parse .cov and .cor files
   description: As a user, I want to be able to parse the `.cov` and `.cor` files in


### PR DESCRIPTION
This PR fixes the `$PROBLEM` parsing issue described in gh-201.  The last commit is the main one of interest.

Note that there are lots of file changes, but most of those are just golden files where "LEM"s are being dropped:

```
$ git diff --name-only main.. ':!*golden*'
parsers/nmparser/parse_run_details.go
parsers/nmparser/parse_run_details_test.go
```
