### PR TITLE
nonmem: fix two help output typos

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -201,7 +201,7 @@ func NewNonmemCmd() *cobra.Command {
 	errpanic(viper.BindPFlag(parafileIdentifier, cmd.PersistentFlags().Lookup(parafileIdentifier)))
 
 	const nmQualIdentifier string = "nmqual"
-	cmd.PersistentFlags().Bool(nmQualIdentifier, false, "Whether or not to execute with nmqual (autolog.pl")
+	cmd.PersistentFlags().Bool(nmQualIdentifier, false, "Whether or not to execute with nmqual (autolog.pl)")
 	errpanic(viper.BindPFlag(nmQualIdentifier, cmd.PersistentFlags().Lookup(nmQualIdentifier)))
 
 	// NMFE Options

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,7 +76,7 @@ func NewRunCmd() *cobra.Command {
 	// cmd.PersistentFlags().String("saveExe", "", "what to name the executable when stored in cache")
 	// viper.BindPFlag("saveExe", cmd.PersistentFlags().Lookup("saveExe"))
 
-	cmd.PersistentFlags().String("output_dir", "{{ .Name }}", "Go template for the output directory to use for storging details of each executed model")
+	cmd.PersistentFlags().String("output_dir", "{{ .Name }}", "Go template for the output directory to use for storing details of each executed model")
 	errpanic(viper.BindPFlag("output_dir", cmd.PersistentFlags().Lookup("output_dir")))
 	viper.SetDefault("output_dir", "{{ .Name }}")
 

--- a/docs/bbi/nonmem/run/run.md
+++ b/docs/bbi/nonmem/run/run.md
@@ -36,7 +36,7 @@ The run command collects a series of flags necessary to define the behavior for:
       --git                 whether git is used
   -h, --help                help for run
       --log_file string     If populated, specifies the file into which to store the output / logging details from bbi
-      --output_dir string   Go template for the output directory to use for storging details of each executed model (default "{{ .Name }}")
+      --output_dir string   Go template for the output directory to use for storing details of each executed model (default "{{ .Name }}")
       --overwrite           Whether or not to remove existing output directories if they are present
       --save_config         Whether or not to save the existing configuration to a file with the model (default true)
 ```


### PR DESCRIPTION
These are two minor typos that have been pointed out in issues.  I want to get the `--nmqual` in before updating bbr's `BBI_ARGS` value (which inherits the same typo).
