### PR TITLE
drone: move built bbi's directory to front of PATH

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,7 +50,7 @@ steps:
   - name: Unit Test
     commands:
       - if [ ! -d /data/${DRONE_BUILD_NUMBER}/apps ] ; then mkdir -p /data/${DRONE_BUILD_NUMBER}/apps; chmod -R 0755 /data/${DRONE_BUILD_NUMBER}/apps; cp bbi /data/${DRONE_BUILD_NUMBER}/apps; else cp bbi /data/${DRONE_BUILD_NUMBER}/apps; fi
-      - export PATH=$PATH:/data/${DRONE_BUILD_NUMBER}/apps
+      - export PATH=/data/${DRONE_BUILD_NUMBER}/apps:$PATH
       - export ROOT_EXECUTION_DIR=/data/${DRONE_BUILD_NUMBER}
       - export BBI_GRID_NAME_PREFIX="drone_${DRONE_BUILD_NUMBER}"
       - bbi init --dir /opt/NONMEM
@@ -82,7 +82,7 @@ steps:
   - name: Integration Test
     commands:
       - if [ ! -d /data/${DRONE_BUILD_NUMBER}/apps ] ; then mkdir -p /data/${DRONE_BUILD_NUMBER}/apps; chmod -R 0755 /data/${DRONE_BUILD_NUMBER}/apps; cp bbi /data/${DRONE_BUILD_NUMBER}/apps; else cp bbi /data/${DRONE_BUILD_NUMBER}/apps; fi
-      - export PATH=$PATH:/data/${DRONE_BUILD_NUMBER}/apps
+      - export PATH=/data/${DRONE_BUILD_NUMBER}/apps:$PATH
       - cd integration
       - export ROOT_EXECUTION_DIR=/data/${DRONE_BUILD_NUMBER}
       - export BBI_GRID_NAME_PREFIX="drone_${DRONE_BUILD_NUMBER}"


### PR DESCRIPTION
.drone.yml builds bbi and copies it to /data/NNN/apps/, and puts that directory at the end of $PATH.  That approach has worked okay for a long time (first occurrence introduced in 3508b4b4, 2020-04-16) because Metworx did not ship with a bbi in any of its PATH directories.  That's no longer the case with the latest Metworx.

Move /data/NNN/apps/ to the front so that the built bbi takes precedence.

---

Thanks to @shairozan for spotting what the issue was.