### PR TITLE
Windows fixes

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/metrumresearchgroup/wrapt"
+)
+
+func TestFindNonMemBinaryWindows(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+	dir := t.TempDir()
+	rdir := filepath.Join(dir, "run")
+	if err := os.Mkdir(rdir, 0777); err != nil {
+		t.Fatal(err)
+	}
+
+	foo := filepath.Join(rdir, "foo.bat")
+	if err := os.WriteFile(foo, []byte(""), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := findNonMemBinaryWindows(dir)
+	t.R.Contains(err.Error(), ".bat file not found")
+
+	nmfe := filepath.Join(rdir, "nmfe23.bat")
+	if err = os.WriteFile(nmfe, []byte(""), 0666); err != nil {
+		t.Fatal(err)
+	}
+
+	binary, err := findNonMemBinaryWindows(dir)
+	t.R.NoError(err)
+	t.R.Equal(binary, "nmfe23.bat")
+}

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -443,7 +443,16 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 
 	log.Debugf("Script location is pegged at %s", scriptLocation)
 
-	command := exec.Command(scriptLocation)
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		return turnstile.ConcurrentError{
+			Error:         err,
+			RunIdentifier: model.FileName,
+			Notes:         fmt.Sprintf("bash is required: %v", err),
+		}
+	}
+
+	command := exec.Command(bash, scriptLocation)
 	command.Dir = model.OutputDir
 	command.Env = os.Environ() // Take in OS Environment
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -448,7 +448,7 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 		return turnstile.ConcurrentError{
 			Error:         err,
 			RunIdentifier: model.FileName,
-			Notes:         fmt.Sprintf("bash is required: %v", err),
+			Notes:         "bash is required to run bbi. Please install bash and then try running this again.",
 		}
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -287,8 +287,13 @@ func ExecutePostWorkDirectivesWithEnvironment(worker PostWorkExecutor) (string, 
 		return "", err
 	}
 
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		return "", err
+	}
+
 	// Needs to be the processed value, not the config template.
-	cmd := exec.Command(filepath.Join(worker.GetWorkingPath(), "post_processing.sh"))
+	cmd := exec.Command(bash, filepath.Join(worker.GetWorkingPath(), "post_processing.sh"))
 
 	// Set the environment for the binary.
 	cmd.Env = environment


### PR DESCRIPTION
 * `bbi init`: fix two incorrect assumptions that made the detection logic for NONMEM always come up empty

   This should be what's behind gh-295.

 * `bbi nonmem run local`: invoke bash explicitly so that we don't rely on shebangs and executable files

---

We're still working on getting a Windows machine with NONMEM installed, so both of these haven't been tested directly.  However, I've did the following indirect tests on a Windows machine without NONMEM.

### first issue

I confirmed that `./bbi.exe init --dir nm/foo` writes out a "nonmem" section with an fake directory that looks like this:

```
$ find nm
nm
nm/foo
nm/foo/bar
nm/foo/bar/license
nm/foo/bar/license/nonmem.lic
nm/foo/bar/run
nm/foo/bar/run/nmfe99.bat
nm/foo/bar/source
nm/foo/bar/util
nm/foo/baz
nm/foo/baz/license
nm/foo/baz/license/nonmem.lic
nm/foo/baz/run
nm/foo/baz/run/nmfe32.bat
nm/foo/baz/run/nmfe33.bat
nm/foo/baz/source
nm/foo/baz/util
```

bbi.yaml excerpt:

```
nonmem:
  bar:
    executable: nmfe99.bat
    home: nm\foo\bar
  baz:
    executable: nmfe32.bat
    home: nm\foo\baz
```


### second issue

Dummy go program:

```go
package main

import (
	"fmt"
	"os"
	"os/exec"
)

func main() {
	bash, err := exec.LookPath("bash")
	if err != nil {
		panic(err)
	}
	fmt.Printf("bash is at %q\n", bash)

	// /usr/bin/bash is where Git for Windows' bash is on the Windows
	// machine.
	if err = os.WriteFile("1.sh", []byte("#!/usr/bin/bash\necho foo"), 0666); err != nil {
		panic(err)
	}

	c := exec.Command(bash, "1.sh")
	out, err := c.CombinedOutput()
	if err != nil {
		panic(err)
	}
	fmt.Printf("%s", out)
}
```

From Git Bash (what RStudio will use by default if available), all is good:

```
Administrator@EC2AMAZ-V9JAO7M MINGW64 ~/scratch
$ ./therealbbi.exe
bash is at "C:\\Program Files\\Git\\usr\\bin\\bash.exe"
foo

Administrator@EC2AMAZ-V9JAO7M MINGW64 ~/scratch
$ ./1.sh
foo
```

From Rtools bash, all is good:

```
Administrator@EC2AMAZ-V9JAO7M MSYS ~/scratch
$ ./therealbbi.exe
bash is at "C:\\rtools40\\usr\\bin\\bash.exe"
foo

Administrator@EC2AMAZ-V9JAO7M MSYS ~/scratch
$ ./1.sh
foo
```

From RStudio (with Rtools on path):

```
> Sys.getenv("PATH")
[1] "C:\\rtools40\\usr\\bin;C:\\Program Files\\R\\R-4.1.3\\bin\\x64;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Amazon\\cfn-bootstrap\\;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLIV2\\;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;"

> processx::run("therealbbi")
$status
[1] 0

$stdout
[1] "bash is at \"C:\\\\rtools40\\\\usr\\\\bin\\\\bash.exe\"\nfoo\n"

$stderr
[1] ""

$timeout
[1] FALSE

> processx::run("1.sh")
Error in `process_initialize(self, private, command, args, stdin, stdout, ...`:
! Native call to `processx_exec` failed
Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...`:
! create process '1.sh' (system error 193, %1 is not a valid Win32 application.
) @win/processx.c:1040 (processx_exec)
Type .Last.error to see the more details.
```

The first process run is supposed to mimic the how bbr would call bbi, and (with this series) bbi would then call `bash x.sh`.  So, all good.

When Git for Windows bin is on path instead, the same processx call looks good:

```
> Sys.getenv("PATH")
[1] "C:\\Program Files\\Git\\bin;C:\\Program Files\\R\\R-4.1.3\\bin\\x64;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Amazon\\cfn-bootstrap\\;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLIV2\\;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;"

> processx::run("therealbbi")
$status
[1] 0

$stdout
[1] "bash is at \"C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe\"\nfoo\n"

$stderr
[1] ""

$timeout
[1] FALSE

> processx::run("1.sh")
Error in `process_initialize(self, private, command, args, stdin, stdout, ...`:
! Native call to `processx_exec` failed
Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...`:
! create process '1.sh' (system error 193, %1 is not a valid Win32 application.
) @win/processx.c:1040 (processx_exec)
Type .Last.error to see the more details.
```


And, if I have neither Rtools or Git for Windows on path, things fail as expected:

```
> processx::run("therealbbi.exe")
Error in `processx::run("therealbbi.exe")`:
! System command 'therealbbi.exe' failed
---
Exit status: 2
Stderr:
panic: exec: "bash": executable file not found in %PATH%

goroutine 1 [running]:
main.main()
    /Users/KyleM/scratch/go-scratchpad/therealbbi.go:12 +0x1bd
---
Type .Last.error to see the more details.
> processx::run("1.sh")
Error in `process_initialize(self, private, command, args, stdin, stdout, ...`:
! Native call to `processx_exec` failed
Caused by error in `chain_call(c_processx_exec, command, c(command, args), pty, pty_options, ...`:
! create process '1.sh' (system error 193, %1 is not a valid Win32 application.
) @win/processx.c:1040 (processx_exec)
Type .Last.error to see the more details.
> Sys.getenv("PATH")
[1] "C:\\Program Files\\R\\R-4.1.3\\bin\\x64;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program Files\\Amazon\\cfn-bootstrap\\;C:\\Program Files\\Git\\cmd;C:\\Program Files\\Amazon\\AWSCLIV2\\;C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\WindowsApps;"
```
