### PR TITLE
init: warn on ID collisions and support NONMEM directories with periods

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -265,7 +265,8 @@ func hasNMQual(path string) bool {
 func makeIdentifiers(locs []string) map[string]string {
 	ids := make(map[string]string)
 	for _, loc := range locs {
-		id := filepath.Base(loc)
+		// Viper keys are case insensitive.
+		id := strings.ToLower(filepath.Base(loc))
 		if loc1, exists := ids[id]; exists {
 			log.Warnf("Ignoring %q because its key collides with %q\n", loc1, loc)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -265,8 +265,8 @@ func hasNMQual(path string) bool {
 func makeIdentifiers(locs []string) map[string]string {
 	ids := make(map[string]string)
 	for _, loc := range locs {
-		// Viper keys are case insensitive.
-		id := strings.ToLower(filepath.Base(loc))
+		// Viper keys are case insensitive and delimited by periods.
+		id := strings.ReplaceAll(strings.ToLower(filepath.Base(loc)), ".", "-")
 		if loc1, exists := ids[id]; exists {
 			log.Warnf("Ignoring %q because its key collides with %q\n", loc1, loc)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,11 +29,11 @@ func initializer(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("get dir string: %w", err)
 	}
 
-	var find_nm func(string) (string, error)
+	var findNM func(string) (string, error)
 	if runtime.GOOS == "windows" {
-		find_nm = findNonMemBinaryWindows
+		findNM = findNonMemBinaryWindows
 	} else {
-		find_nm = findNonMemBinary
+		findNM = findNonMemBinary
 	}
 
 	for _, l := range dir {
@@ -59,7 +59,7 @@ func initializer(cmd *cobra.Command, _ []string) error {
 
 		for _, v := range locations {
 			var nm string
-			nm, err = find_nm(v)
+			nm, err = findNM(v)
 			if err != nil {
 				log.Println(err)
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -76,7 +76,9 @@ func initializer(cmd *cobra.Command, _ []string) error {
 	}
 
 	c := configlib.Config{}
-	errpanic(viper.Unmarshal(&c))
+	if err = viper.Unmarshal(&c); err != nil {
+		return err
+	}
 
 	yamlString, err := yaml.Marshal(c)
 	if err != nil {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -22,6 +22,7 @@ func TestFindNonMemBinaryWindows(tt *testing.T) {
 	}
 
 	_, err := findNonMemBinaryWindows(dir)
+	t.R.Error(err)
 	t.R.Contains(err.Error(), ".bat file not found")
 
 	nmfe := filepath.Join(rdir, "nmfe23.bat")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -179,3 +179,28 @@ func TestInitMakeNonmemEntriesCollisionCase(tt *testing.T) {
 		t.R.Equal(keys(es), []string{"nm75"})
 	})
 }
+
+func TestInitMakeNonmemEntriesKeySanitization(tt *testing.T) {
+	id := "UNIT-INIT-005"
+	tt.Run(utils.AddTestId("", id), func(tt *testing.T) {
+		t := wrapt.WrapT(tt)
+		tdir := t.TempDir()
+
+		name := "nm.75"
+		if err := setupDir(filepath.Join(tdir, name)); err != nil {
+			t.Fatal(err)
+		}
+
+		es, err := makeNonmemEntries([]string{tdir})
+		t.R.NoError(err)
+		t.R.Equal(es["nm-75"].Home, filepath.Join(tdir, name))
+
+		if err = setupDir(filepath.Join(tdir, "nm-75")); err != nil {
+			t.Fatal(err)
+		}
+
+		es, err = makeNonmemEntries([]string{tdir})
+		t.R.NoError(err)
+		t.R.Equal(keys(es), []string{"nm-75"})
+	})
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -150,5 +151,31 @@ func TestInitMakeNonmemEntriesCollisionAcrossDirs(tt *testing.T) {
 		es, err := makeNonmemEntries(dirs)
 		t.R.NoError(err)
 		t.R.Equal(keys(es), []string{name})
+	})
+}
+
+func TestInitMakeNonmemEntriesCollisionCase(tt *testing.T) {
+	id := "UNIT-INIT-004"
+	tt.Run(utils.AddTestId("", id), func(tt *testing.T) {
+		t := wrapt.WrapT(tt)
+		tdir := t.TempDir()
+
+		if err := setupDir(filepath.Join(tdir, "NM75")); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := os.Stat(filepath.Join(tdir, "nm75")); err == nil {
+			t.Skip("Cannot test on case-insensitive file system")
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+
+		if err := setupDir(filepath.Join(tdir, "nm75")); err != nil {
+			t.Fatal(err)
+		}
+
+		es, err := makeNonmemEntries([]string{tdir})
+		t.R.NoError(err)
+		t.R.Equal(keys(es), []string{"nm75"})
 	})
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/metrumresearchgroup/bbi/configlib"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -108,5 +109,46 @@ func TestInitMakeNonmemEntriesMultiple(tt *testing.T) {
 		t.R.NoError(err)
 		t.R.Equal(es[names[0]].Home, filepath.Join(d1, names[0]))
 		t.R.Equal(es[names[1]].Home, filepath.Join(d2, names[1]))
+	})
+}
+
+func keys(m map[string]configlib.NonMemDetail) []string {
+	ks := make([]string, len(m))
+	i := 0
+	for k := range m {
+		ks[i] = k
+		i++
+	}
+
+	return ks
+}
+
+func TestInitMakeNonmemEntriesCollisionAcrossDirs(tt *testing.T) {
+	id := "UNIT-INIT-003"
+	tt.Run(utils.AddTestId("", id), func(tt *testing.T) {
+		t := wrapt.WrapT(tt)
+		tdir := t.TempDir()
+
+		d1 := filepath.Join(tdir, "d1")
+		if err := os.Mkdir(d1, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		d2 := filepath.Join(tdir, "d2")
+		if err := os.Mkdir(d2, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		name := "nm75"
+		dirs := []string{d1, d2}
+		for _, d := range dirs {
+			if err := setupDir(filepath.Join(d, name)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		es, err := makeNonmemEntries(dirs)
+		t.R.NoError(err)
+		t.R.Equal(keys(es), []string{name})
 	})
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+
+	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
 )
@@ -33,4 +36,77 @@ func TestFindNonMemBinaryWindows(tt *testing.T) {
 	binary, err := findNonMemBinaryWindows(dir)
 	t.R.NoError(err)
 	t.R.Equal(binary, "nmfe23.bat")
+}
+
+func setupDir(dir string) error {
+	for _, d := range []string{"license", "run", "util", "source"} {
+		sdir := filepath.Join(dir, d)
+		if err := os.MkdirAll(sdir, 0777); err != nil {
+			return err
+		}
+	}
+
+	lic := filepath.Join(dir, "license", "nonmem.lic")
+	if err := os.WriteFile(lic, []byte(""), 0666); err != nil {
+		return err
+	}
+
+	nmfe := filepath.Join(dir, "run", "nmfe12")
+	if runtime.GOOS == "windows" {
+		nmfe = nmfe + ".bat"
+	}
+
+	if err := os.WriteFile(nmfe, []byte(""), 0777); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestInitMakeNonmemEntries(tt *testing.T) {
+	id := "UNIT-INIT-001"
+	tt.Run(utils.AddTestId("", id), func(tt *testing.T) {
+		t := wrapt.WrapT(tt)
+		tdir := t.TempDir()
+
+		name := "nm75"
+		if err := setupDir(filepath.Join(tdir, name)); err != nil {
+			t.Fatal(err)
+		}
+
+		es, err := makeNonmemEntries([]string{tdir})
+		t.R.NoError(err)
+		t.R.Equal(es[name].Home, filepath.Join(tdir, name))
+	})
+}
+
+func TestInitMakeNonmemEntriesMultiple(tt *testing.T) {
+	id := "UNIT-INIT-002"
+	tt.Run(utils.AddTestId("", id), func(tt *testing.T) {
+		t := wrapt.WrapT(tt)
+		tdir := t.TempDir()
+
+		d1 := filepath.Join(tdir, "d1")
+		if err := os.Mkdir(d1, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		d2 := filepath.Join(tdir, "d2")
+		if err := os.Mkdir(d2, 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		dirs := []string{d1, d2}
+		names := []string{"nm1", "nm2"}
+		for i, d := range dirs {
+			if err := setupDir(filepath.Join(d, names[i])); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		es, err := makeNonmemEntries(dirs)
+		t.R.NoError(err)
+		t.R.Equal(es[names[0]].Home, filepath.Join(d1, names[0]))
+		t.R.Equal(es[names[1]].Home, filepath.Join(d2, names[1]))
+	})
 }

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -26,6 +26,8 @@ INIT-R001:
   description: BBI can initialize
   tests:
   - INT-INIT-001
+  - UNIT-INIT-001
+  - UNIT-INIT-002
 LOCAL-R001:
   description: BBI completes local execution
   tests:

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -29,6 +29,7 @@ INIT-R001:
   - UNIT-INIT-001
   - UNIT-INIT-002
   - UNIT-INIT-003
+  - UNIT-INIT-004
 LOCAL-R001:
   description: BBI completes local execution
   tests:

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -28,6 +28,7 @@ INIT-R001:
   - INT-INIT-001
   - UNIT-INIT-001
   - UNIT-INIT-002
+  - UNIT-INIT-003
 LOCAL-R001:
   description: BBI completes local execution
   tests:

--- a/validation/requirements.yaml
+++ b/validation/requirements.yaml
@@ -26,10 +26,12 @@ INIT-R001:
   description: BBI can initialize
   tests:
   - INT-INIT-001
+  - INT-INIT-002
   - UNIT-INIT-001
   - UNIT-INIT-002
   - UNIT-INIT-003
   - UNIT-INIT-004
+  - UNIT-INIT-005
 LOCAL-R001:
   description: BBI completes local execution
   tests:


### PR DESCRIPTION
This series was prompted by `bbi init` mishandling a directory with periods.  For example, a directory with the name "7.5.0" will lead to this entry:

```
nonmem:
  "7": {}
```

<details>
<summary>demo script</summary>

```sh
#!/bin/sh

set -eu

tdir=$(mktemp -d "${TMPDIR:-/tmp}"/bbi-init-test-XXXXXXX)

test $# != 0 || {
    echo "usage: $0 <NONMEM name>"
    exit 1
}

cd "$tdir"

for nm_name in "$@"
do

    for sdir in license run util source
    do
        mkdir -p d/"$nm_name"/"$sdir"
    done

    :> d/"$nm_name"/license/nonmem.lic
    :> d/"$nm_name"/run/nmfe75
    chmod +x d/"$nm_name"/run/nmfe75
done

bbi init --dir d

cat bbi.yaml
```

```
./demo.sh 7.5.0 | grep nonmem -A1
nonmem:
  "7": {}
```

</details>

After the last commit, that will be accessible as "7-5-0".

---

```
init: rename variable for style consistency
init_test: check that error is non-nil before inspecting message
init: convert a panic to a returned error
```

These first three commits touch up minor things in the area that aren't directly related to the original problem.

```
init: extract logic for finding installation directories to function
init: generate NonMemDetail map directly
```

The next commits split up and reworks the implementation a bit, mostly for easier testing (but I also think it makes things a bit clearer).

```
init: warn on identifier collisions
init: detect collision due case insensitive keys
```

These two commits add collision warnings for two cases that could be hit before this PR.

```
init: sanitize config identifier for nonmem entries
```

The last commit handles the "." to "-" replacement, warning if that creates any collisions.
