### PR TITLE
integration: test period_test scenario

### DIFF
--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -24,6 +24,7 @@ func TestBbiCompletesLocalExecution(tt *testing.T) {
 		{name: "metrum_std"},
 		{name: "leading-path-with space"},
 		{name: "modquote"},
+		{name: "period_test"},
 		{name: "datacomment"},
 	}
 


### PR DESCRIPTION
As of aa686d3 (tests: removing more scenarios from tests that don't need so many divergent paths [...], 2021-09-23), the period_test scenario is no longer used by any tests.  This scenario provides a regression test for a fix in v2.3.1, so it's worth keeping around.

Restore its use in TestBbiCompletesLocalExecution.