### PR TITLE
Fix setup of config file for `TestSpecifiedConfig*` tests

### DIFF
--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -259,6 +259,25 @@ func TestDefaultConfigLoaded(tt *testing.T) {
 	}
 }
 
+func copyConfig(t *wrapt.T) {
+	t.Helper()
+
+	fs := afero.NewOsFs()
+
+	if ok, _ := afero.DirExists(fs, filepath.Join(ROOT_EXECUTION_DIR, "meow")); ok {
+		t.R.NoError(fs.RemoveAll(filepath.Join(ROOT_EXECUTION_DIR, "meow")))
+	}
+
+	t.R.NoError(fs.MkdirAll(filepath.Join(ROOT_EXECUTION_DIR, "meow"), 0755))
+	// Copy the bbi file here
+	source, _ := fs.Open("bbi.yaml")
+	defer t.R.NoError(source.Close())
+	dest, _ := fs.Create(filepath.Join(ROOT_EXECUTION_DIR, "meow", "bbi.yaml"))
+	defer t.R.NoError(dest.Close())
+
+	_, _ = io.Copy(dest, source)
+}
+
 func TestSpecifiedConfigByAbsPathLoaded(tt *testing.T) {
 	SkipIfNotEnabled(tt, "LOCAL")
 
@@ -266,21 +285,7 @@ func TestSpecifiedConfigByAbsPathLoaded(tt *testing.T) {
 	func() {
 		tt.Run(utils.AddTestId("", testId), func(tt *testing.T) {
 			t := wrapt.WrapT(tt)
-
-			fs := afero.NewOsFs()
-
-			if ok, _ := afero.DirExists(fs, filepath.Join(ROOT_EXECUTION_DIR, "meow")); ok {
-				t.R.NoError(fs.RemoveAll(filepath.Join(ROOT_EXECUTION_DIR, "meow")))
-			}
-
-			t.R.NoError(fs.MkdirAll(filepath.Join(ROOT_EXECUTION_DIR, "meow"), 0755))
-			// Copy the bbi file here
-			source, _ := fs.Open("bbi.yaml")
-			defer t.R.NoError(source.Close())
-			dest, _ := fs.Create(filepath.Join(ROOT_EXECUTION_DIR, "meow", "bbi.yaml"))
-			defer t.R.NoError(dest.Close())
-
-			_, _ = io.Copy(dest, source)
+			copyConfig(t)
 		})
 	}()
 
@@ -336,21 +341,7 @@ func TestSpecifiedConfigByRelativePathLoaded(tt *testing.T) {
 	testId := "INT-LOCAL-006"
 	tt.Run(utils.AddTestId("", testId), func(tt *testing.T) {
 		t := wrapt.WrapT(tt)
-
-		fs := afero.NewOsFs()
-
-		if ok, _ := afero.DirExists(fs, filepath.Join(ROOT_EXECUTION_DIR, "meow")); ok {
-			t.R.NoError(fs.RemoveAll(filepath.Join(ROOT_EXECUTION_DIR, "meow")))
-		}
-
-		t.R.NoError(fs.MkdirAll(filepath.Join(ROOT_EXECUTION_DIR, "meow"), 0755))
-		// Copy the bbi file here
-		source, _ := fs.Open("bbi.yaml")
-		defer t.R.NoError(source.Close())
-		dest, _ := fs.Create(filepath.Join(ROOT_EXECUTION_DIR, "meow", "bbi.yaml"))
-		defer t.R.NoError(dest.Close())
-
-		_, _ = io.Copy(dest, source)
+		copyConfig(t)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()

--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -273,9 +273,11 @@ func copyConfig(t *wrapt.T) string {
 
 	t.R.NoError(fs.MkdirAll(dir, 0755))
 	source, _ := fs.Open("bbi.yaml")
-	defer t.R.NoError(source.Close())
+	defer source.Close()
 	dest, _ := fs.Create(config)
-	defer t.R.NoError(dest.Close())
+	defer func() {
+		t.R.NoError(dest.Close())
+	}()
 
 	_, _ = io.Copy(dest, source)
 

--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -269,7 +269,6 @@ func copyConfig(t *wrapt.T) {
 	}
 
 	t.R.NoError(fs.MkdirAll(filepath.Join(ROOT_EXECUTION_DIR, "meow"), 0755))
-	// Copy the bbi file here
 	source, _ := fs.Open("bbi.yaml")
 	defer t.R.NoError(source.Close())
 	dest, _ := fs.Create(filepath.Join(ROOT_EXECUTION_DIR, "meow", "bbi.yaml"))
@@ -347,7 +346,6 @@ func TestSpecifiedConfigByRelativePathLoaded(tt *testing.T) {
 		defer cancel()
 		scenario := InitializeScenario(t, "acop")
 
-		// Copy config to /${ROOT_EXECUTION_DIR}/meow/bbi.yaml
 		nonMemArguments := []string{
 			"-d",
 			"--config",

--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -272,14 +272,17 @@ func copyConfig(t *wrapt.T) string {
 	}
 
 	t.R.NoError(fs.MkdirAll(dir, 0755))
-	source, _ := fs.Open("bbi.yaml")
+	source, err := fs.Open("bbi.yaml")
+	t.R.NoError(err)
 	defer source.Close()
-	dest, _ := fs.Create(config)
+	dest, err := fs.Create(config)
+	t.R.NoError(err)
 	defer func() {
 		t.R.NoError(dest.Close())
 	}()
 
-	_, _ = io.Copy(dest, source)
+	_, err = io.Copy(dest, source)
+	t.R.NoError(err)
 
 	return config
 }

--- a/integration/bbi_local_test.go
+++ b/integration/bbi_local_test.go
@@ -281,13 +281,6 @@ func TestSpecifiedConfigByAbsPathLoaded(tt *testing.T) {
 	SkipIfNotEnabled(tt, "LOCAL")
 
 	testId := "INT-LOCAL-005"
-	func() {
-		tt.Run(utils.AddTestId("", testId), func(tt *testing.T) {
-			t := wrapt.WrapT(tt)
-			copyConfig(t)
-		})
-	}()
-
 	tests := []struct {
 		name string
 	}{
@@ -299,6 +292,7 @@ func TestSpecifiedConfigByAbsPathLoaded(tt *testing.T) {
 	for _, test := range tests {
 		tt.Run(utils.AddTestId(test.name, testId), func(tt *testing.T) {
 			t := wrapt.WrapT(tt)
+			copyConfig(t)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 			defer cancel()


### PR DESCRIPTION
When working on gh-307, I noticed that, despite passing, `TestSpecifiedConfigByAbsPathLoaded` and `TestSpecifiedConfigByRelativePathLoaded` have an error in their output:

```
=== RUN   TestSpecifiedConfigByRelativePathLoaded/[INT-LOCAL-006]/acop[INT-LOCAL-006]
INFO[0000] Command was 'bbi' while arguments were -d --config /tmp/bbi-test-w0wYU5G/meow/bbi.yaml nonmem run local --nm_version nm75 /tmp/bbi-test-w0wYU5G/working/acop/acop.mod
ERRO[0000] An error occurred trying to execute model. Error details are : exit status 1
ERRO[0000] Exit code was 1, details were exit status 1
ERRO[0000] output details were: time="2023-10-06T10:01:13-04:00" level=info msg="Successfully loaded specified configuration from /tmp/bbi-test-w0wYU5G/meow/bbi.yaml"
time="2023-10-06T10:01:13-04:00" level=info msg="Beginning Local Path"
time="2023-10-06T10:01:13-04:00" level=info msg="Setting logging to DEBUG"
time="2023-10-06T10:01:13-04:00" level=debug msg="Locating models from arguments"
time="2023-10-06T10:01:13-04:00" level=info msg="A total of 1 models have completed the initial preparation phase"
time="2023-10-06T10:01:13-04:00" level=debug msg="Building turnstile manager"
time="2023-10-06T10:01:13-04:00" level=debug msg="Beginning turnstile execution"
time="2023-10-06T10:01:13-04:00" level=info msg="Manager Details: Working: 0, Errors: 0, Completed: 0, Concurrency: 4, Iterations: 1"
time="2023-10-06T10:01:13-04:00" level=debug msg="[acop] Beginning local preparation phase"
time="2023-10-06T10:01:13-04:00" level=debug msg="[acop] Overwrite is currently set to true"
time="2023-10-06T10:01:13-04:00" level=debug msg="[acop] Writing initial gitignore file"
time="2023-10-06T10:01:13-04:00" level=debug msg="Requested save of config file /tmp/bbi-test-w0wYU5G/working/acop/acop"
time="2023-10-06T10:01:13-04:00" level=debug msg="[acop] Creating local execution script"
time="2023-10-06T10:01:13-04:00" level=debug msg="[acop] beginning script command generation. NMQual is set to false"
time="2023-10-06T10:01:13-04:00" level=fatal msg="nmVersion of  was provided but has no configurations in bbi.yaml!"
--- PASS: TestSpecifiedConfigByRelativePathLoaded (0.02s)
    --- PASS: TestSpecifiedConfigByRelativePathLoaded/[INT-LOCAL-006] (0.02s)
        --- PASS: TestSpecifiedConfigByRelativePathLoaded/[INT-LOCAL-006]/acop[INT-LOCAL-006] (0.00s)
```

That error is due to unintentionally passing an empty `bbi.yaml` file.  The second to last commit of this series fixes that, and the last commit provides more extensive error checking to avoid similar errors in this code going unnoticed.

---

This is ready to review but should be merged after its base (gh-307).
