### PR TITLE
ci: update lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,11 +6,6 @@ on:
       - 'scratch/**'
   pull_request:
 
-# Note: this avoids golangci/golangci-lint-action to work around an
-# error triggered by us pinning to a golangci-lint version built with
-# an older Go.  Revisit when moving from golangci-lint v1.47.2.
-#
-# https://github.com/golangci/golangci-lint-action/issues/442#issuecomment-1203786890
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -18,16 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
-      - name: Install golangci-lint
-        shell: bash
-        run: |
-          bin=$(mktemp -d)
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
-            sh -s -- -b "$bin" v1.47.2
-          echo "$bin" >>$GITHUB_PATH
+          go-version: stable
       - name: Run golangci-lint
-        shell: bash
-        run: |
-          command -v golangci-lint
-          golangci-lint run --out-format=github-actions
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,16 +37,13 @@ run:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
 #    - gosec
     - unparam
     - unconvert
@@ -58,5 +55,4 @@ linters:
     - whitespace
     - rowserrcheck
     - godot
-    - ifshort
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,7 @@ linters-settings:
   errcheck:
     check-type-assertions: true
   govet:
-    check-shadowing: true
+    shadow: true
   unparam:
     check-exported: true
   unused:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ issues:
         - gocyclo
         - dupl
         - gosec
+  exclude-dirs:
+    - (^|/)mock($|/)
 
 linters-settings:
   errcheck:
@@ -31,8 +33,6 @@ linters-settings:
 
 run:
   skip-dirs-use-default: true
-  skip-dirs:
-    - (^|/)mock($|/)
   timeout: 3m
 
 linters:

--- a/cmd/bbi/main.go
+++ b/cmd/bbi/main.go
@@ -8,6 +8,7 @@ import (
 var buildTime string
 
 // if want to generate docs
+//
 //	import "github.com/spf13/cobra/doc"
 //	err := doc.GenMarkdownTree(cmd.RootCmd, "../../docs/bbi")
 //	if err != nil {

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -30,7 +30,7 @@ type sgeOperation struct {
 	Models []SGEModel `json:"models"`
 }
 
-//SGEModel is the struct used for SGE operations containing the NonMemModel.
+// SGEModel is the struct used for SGE operations containing the NonMemModel.
 type SGEModel struct {
 	Nonmem               *NonMemModel
 	Cancel               chan bool
@@ -66,12 +66,12 @@ func (s *SGEModel) GetWorkingPath() string {
 	return s.Nonmem.OutputDir
 }
 
-//Begin Scalable method definitions.
+// Begin Scalable method definitions.
 func (l SGEModel) CancellationChannel() chan bool {
 	return l.Cancel
 }
 
-//Prepare is basically the old EstimateModel function. Responsible for creating directories and preparation.
+// Prepare is basically the old EstimateModel function. Responsible for creating directories and preparation.
 func (l SGEModel) Prepare(channels *turnstile.ChannelMap) {
 	log.Debugf("%s Beginning Prepare phase of SGE Work", l.Nonmem.LogIdentifier())
 
@@ -122,7 +122,7 @@ func (l SGEModel) Prepare(channels *turnstile.ChannelMap) {
 	}
 }
 
-//Work describes the Turnstile execution phase -> IE What heavy lifting should be done.
+// Work describes the Turnstile execution phase -> IE What heavy lifting should be done.
 func (l SGEModel) Work(channels *turnstile.ChannelMap) {
 	cerr := executeNonMemJob(executeSGEJob, l.Nonmem)
 
@@ -139,12 +139,12 @@ func (l SGEModel) Work(channels *turnstile.ChannelMap) {
 	channels.Completed <- 1
 }
 
-//Monitor is the 3rd phase of turnstile (not implemented here).
+// Monitor is the 3rd phase of turnstile (not implemented here).
 func (l SGEModel) Monitor(_ *turnstile.ChannelMap) {
 	//Do nothing for this implementation
 }
 
-//Cleanup is the last phase of execution, in which computation / hard work is done and we're cleaning up leftover files, copying results around et all.
+// Cleanup is the last phase of execution, in which computation / hard work is done and we're cleaning up leftover files, copying results around et all.
 func (l SGEModel) Cleanup(_ *turnstile.ChannelMap) {
 	//err := configlib.WriteViperConfig(l.Nonmem.OutputDir, true)
 	//
@@ -352,7 +352,7 @@ func sgeModelsFromArguments(args []string, config configlib.Config) ([]SGEModel,
 	return output, nil
 }
 
-//Generate the command line script to execute bbi on the grid.
+// Generate the command line script to execute bbi on the grid.
 func generateBbiScript(fileTemplate string, l NonMemModel) ([]byte, error) {
 	t, err := template.New("file").Parse(fileTemplate)
 	buf := new(bytes.Buffer)

--- a/integration/nonmem/bbi_expansion_test.go
+++ b/integration/nonmem/bbi_expansion_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -39,7 +39,7 @@ func TestBBIExpandsWithoutPrefix(tt *testing.T) {
 			filepath.Join(scenario.Workpath, "model", targets),
 		}
 
-		output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+		output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 		t.R.NoError(err)
 		t.R.NotEmpty(output)
@@ -108,7 +108,7 @@ func TestBBIExpandsWithPrefix(tt *testing.T) {
 			filepath.Join(scenario.Workpath, "model", targets),
 		}
 
-		output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+		output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 		t.R.NoError(err)
 		t.R.NotEmpty(output)
@@ -178,7 +178,7 @@ func TestBBIExpandsWithPrefixToPartialMatch(tt *testing.T) {
 				filepath.Join(scenario.Workpath, "model", targets),
 			}
 
-			output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+			output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 			t.R.NoError(err)
 			t.R.NotEmpty(output)

--- a/integration/nonmem/bbi_local_test.go
+++ b/integration/nonmem/bbi_local_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -136,7 +136,7 @@ func TestNMFEOptionsEndInScript(tt *testing.T) {
 
 					// Now let's run the script that was generated
 					t.R.NoError(os.Chdir(filepath.Join(scenario.Workpath, m.identifier)))
-					_, err = ExecuteCommand(ctx, filepath.Join(scenario.Workpath, m.identifier, m.identifier+".sh"))
+					_, err = bi.ExecuteCommand(ctx, filepath.Join(scenario.Workpath, m.identifier, m.identifier+".sh"))
 					t.R.NoError(os.Chdir(whereami))
 					t.R.NoError(err)
 

--- a/integration/nonmem/init_test.go
+++ b/integration/nonmem/init_test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -35,7 +35,7 @@ func TestInitialization(tt *testing.T) {
 			scenario.Prepare(t, context.Background())
 
 			t.Run(fmt.Sprintf("init_%s", scenario.identifier), func(t *wrapt.T) {
-				_, err := ExecuteCommand(context.Background(), "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
+				_, err := bi.ExecuteCommand(context.Background(), "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
 				t.R.NoError(err)
 
 				t.A.FileExists(filepath.Join(scenario.Workpath, "bbi.yaml"))

--- a/integration/nonmem/setup.go
+++ b/integration/nonmem/setup.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 
 	"github.com/metrumresearchgroup/wrapt"
 	log "github.com/sirupsen/logrus"
@@ -61,7 +61,7 @@ func (m Model) Execute(scenario *Scenario, args ...string) (string, error) {
 		filepath.Join(scenario.Workpath, m.filename),
 	}...)
 
-	return ExecuteCommand(scenario.ctx, "bbi", cmdArguments...)
+	return bi.ExecuteCommand(scenario.ctx, "bbi", cmdArguments...)
 }
 
 var ErrNoModelsLocated = errors.New("no model directories were located in the provided scenario")
@@ -431,7 +431,7 @@ func findModelFiles(path string) []string {
 func (scenario *Scenario) Prepare(t *wrapt.T, ctx context.Context) {
 	t.Helper()
 
-	_, err := ExecuteCommand(ctx, "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
+	_, err := bi.ExecuteCommand(ctx, "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
 	t.R.NoError(err)
 
 	fs := afero.NewOsFs()
@@ -451,7 +451,7 @@ func (scenario *Scenario) Prepare(t *wrapt.T, ctx context.Context) {
 
 	t.R.NoError(os.Chdir(scenario.Workpath))
 
-	_, err = ExecuteCommand(ctx, "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
+	_, err = bi.ExecuteCommand(ctx, "bbi", "init", "--dir", os.Getenv("NONMEMROOT"))
 	t.R.NoError(err)
 
 	t.R.NoError(os.Chdir(whereami))

--- a/integration/postrun/bbi_covcor_test.go
+++ b/integration/postrun/bbi_covcor_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -33,7 +33,7 @@ func TestCovCorHappyPath(tt *testing.T) {
 				filepath.Join(SUMMARY_TEST_DIR, mod.name, mod.name),
 			}
 
-			output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+			output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 			t.R.NoError(err)
 			t.R.NotEmpty(output)
@@ -75,7 +75,7 @@ func TestCovCorErrors(tt *testing.T) {
 
 			// try without flag and get error
 			var output string
-			output, err := ExecuteCommandNoErrorCheck(context.Background(), "bbi", commandAndArgs...)
+			output, err := bi.ExecuteCommandNoErrorCheck(context.Background(), "bbi", commandAndArgs...)
 			t.R.Error(err)
 
 			errorMatch := rgx.MatchString(output)

--- a/integration/postrun/bbi_params_test.go
+++ b/integration/postrun/bbi_params_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 	"github.com/metrumresearchgroup/wrapt"
 )
@@ -39,7 +39,7 @@ func TestParamsSingleModel(tt *testing.T) {
 				commandAndArgs = append(commandAndArgs, tc.bbiOption)
 			}
 
-			output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+			output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 			t.R.NoError(err)
 			t.R.NotEmpty(output)
@@ -75,7 +75,7 @@ func TestParamsDir(tt *testing.T) {
 				commandAndArgs = append(commandAndArgs, tc.bbiOption)
 			}
 
-			output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+			output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 			t.R.NoError(err)
 			t.R.NotEmpty(output)

--- a/integration/postrun/bbi_reclean_test.go
+++ b/integration/postrun/bbi_reclean_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/wrapt"
 )
 
@@ -23,7 +23,7 @@ func TestBBIRecleanBasic(tt *testing.T) {
 	_ = os.WriteFile(fdataCSV, []byte("fake"), 0644)
 	t.A.FileExists(fdataCSV)
 
-	output, err := ExecuteCommand(context.Background(),
+	output, err := bi.ExecuteCommand(context.Background(),
 		"bbi", "nonmem", "reclean", "--recleanLvl=1", "-v", dir)
 	t.R.NoError(err)
 	t.R.NotEmpty(output)
@@ -34,7 +34,7 @@ func TestBBIRecleanBasic(tt *testing.T) {
 func TestBBIRecleanError(tt *testing.T) {
 	t := wrapt.WrapT(tt)
 
-	output, err := ExecuteCommandNoErrorCheck(context.Background(),
+	output, err := bi.ExecuteCommandNoErrorCheck(context.Background(),
 		"bbi", "nonmem", "reclean")
 
 	t.R.NotNil(err)

--- a/integration/postrun/bbi_summary_test.go
+++ b/integration/postrun/bbi_summary_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	. "github.com/metrumresearchgroup/bbi/integration"
+	bi "github.com/metrumresearchgroup/bbi/integration"
 	"github.com/metrumresearchgroup/bbi/utils"
 
 	"github.com/metrumresearchgroup/wrapt"
@@ -65,7 +65,7 @@ func TestSummaryHappyPath(tt *testing.T) {
 						commandAndArgs = append(commandAndArgs, tc.bbiOption)
 					}
 
-					output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+					output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 					t.R.NoError(err)
 					t.R.NotEmpty(output)
@@ -131,14 +131,14 @@ func TestSummaryArgs(tt *testing.T) {
 					}
 
 					// try without flag and get error
-					output, err := ExecuteCommandNoErrorCheck(context.Background(), "bbi", commandAndArgs...)
+					output, err := bi.ExecuteCommandNoErrorCheck(context.Background(), "bbi", commandAndArgs...)
 					t.R.NotNil(err)
 					errorMatch, _ := regexp.MatchString(tm.errorRegEx, output)
 					t.R.True(errorMatch)
 
 					// append flag and get success
 					commandAndArgs = append(commandAndArgs, tm.bbiArg)
-					output, err = ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+					output, err = bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 					t.R.NoError(err)
 					t.R.NotEmpty(output)
@@ -217,7 +217,7 @@ func TestSummaryErrors(tt *testing.T) {
 				args = append(args, tc.bbiArgs...)
 			}
 			args = append(args, filepath.Join(SUMMARY_TEST_DIR, tc.testPath))
-			output, err := ExecuteCommandNoErrorCheck(context.Background(), "bbi", args...)
+			output, err := bi.ExecuteCommandNoErrorCheck(context.Background(), "bbi", args...)
 			t.R.NotNil(err)
 			errorMatch, _ := regexp.MatchString(tc.errorMsg, output)
 			t.R.True(errorMatch)
@@ -238,7 +238,7 @@ func TestSummaryHappyPathNoExtension(tt *testing.T) {
 			filepath.Join(SUMMARY_TEST_DIR, mod, mod), // adding no extension should work
 		}
 
-		output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+		output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 		t.R.NoError(err)
 		t.R.NotEmpty(output)
@@ -269,7 +269,7 @@ func TestSummaryHappyPathMultipleModels(tt *testing.T) {
 				if tc.bbiOption != "" {
 					commandAndArgs = append(commandAndArgs, tc.bbiOption)
 				}
-				output, err := ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
+				output, err := bi.ExecuteCommand(context.Background(), "bbi", commandAndArgs...)
 
 				gtd := GoldenFileTestingDetails{
 					outputString: output,
@@ -307,7 +307,7 @@ func TestSummaryPathMultipleModelsError(tt *testing.T) {
 				if tc.bbiOption != "" {
 					commandAndArgs = append(commandAndArgs, tc.bbiOption)
 				}
-				output, err := ExecuteCommandNoErrorCheck(context.Background(),
+				output, err := bi.ExecuteCommandNoErrorCheck(context.Background(),
 					"bbi", commandAndArgs...)
 
 				// Avoid testing plain output with golden file due to

--- a/parsers/nmparser/diagonal_elements.go
+++ b/parsers/nmparser/diagonal_elements.go
@@ -7,18 +7,20 @@ import (
 
 // lowerDiagonalLengthToDimension takes l which is
 // the number of total elements in the lower diagonal
-//  matrix, and calculates the dimension (aka number of
+// matrix, and calculates the dimension (aka number of
 // diagonal elements) for the matrix.
 // Additionally, this function can be used to pass
 // a specific index from the array of lower diagonal
 // elements (as l). In that case, it will return one
 // of the following:
 // * If the index is a diagonal element:
-//   * The number of that diagonal element
-//   * true
+//   - The number of that diagonal element
+//   - true
+//
 // * If the index is not a diagonal element:
-//   * 0
-//   * false
+//   - 0
+//   - false
+//
 // For example, there are 6 elements in the lower
 // diagonal of a 3x3 matrix, the 1st, 3rd, and 6th
 // being diagonals. Calling this function on 1-6

--- a/parsers/nmparser/parse_initial_estimates_test.go
+++ b/parsers/nmparser/parse_initial_estimates_test.go
@@ -1,15 +1,17 @@
 package parser
 
 // example omega initial estimates given complex omega structure
-// IOV = EXP(ETA(3))
-// IF(VISI.EQ.6) IOV=EXP(ETA(4))
-// IF(VISI.EQ.8) IOV=EXP(ETA(5))
-// $OMEGA  0.14  ; 1 IIV BASE
-// $OMEGA  0.8  ; 2 IIV EC50
-// $OMEGA  BLOCK(1)
-//  0.03  ; 1 IOV BASE
-// $OMEGA  BLOCK(1) SAME
-// $OMEGA  BLOCK(1) SAME.
+//
+//	IOV = EXP(ETA(3))
+//	IF(VISI.EQ.6) IOV=EXP(ETA(4))
+//	IF(VISI.EQ.8) IOV=EXP(ETA(5))
+//	$OMEGA  0.14  ; 1 IIV BASE
+//	$OMEGA  0.8  ; 2 IIV EC50
+//	$OMEGA  BLOCK(1)
+//	 0.03  ; 1 IOV BASE
+//	$OMEGA  BLOCK(1) SAME
+//	$OMEGA  BLOCK(1) SAME
+//
 // TODO: remove omegaBlock01 if we find no use.
 var _ = /*omegaBlock01*/ []string{
 	"0INITIAL ESTIMATE OF OMEGA:",

--- a/parsers/nmparser/read_ext.go
+++ b/parsers/nmparser/read_ext.go
@@ -40,7 +40,7 @@ func ParseExtLines(lines []string) ExtData {
 	}
 }
 
-//ParseParamsExt returns the ExtData in the structure of final parameter estimates
+// ParseParamsExt returns the ExtData in the structure of final parameter estimates
 // the parameter names correspond to the names per the ext file (THETA1, THETA2, etc)
 // per nonmem 7.4 the following information will be grabbed
 // 1) Theburn-in iterations of the MCMCBayesian analysis are given negative values,starting at –NBURN, the number of burn-in iterations requested by the user. These are followed by positive iterations of the stationary phase.
@@ -149,7 +149,7 @@ func ParseParamsExt(ed ExtData) ([]ParametersData, ParameterNames) {
 	}
 }
 
-//ParseConditionNumberExt returns the condition number for each estimation method from ExtData
+// ParseConditionNumberExt returns the condition number for each estimation method from ExtData
 // per nonmem 7.4 the following information will be grabbed
 // Iteration -1000000003 indicates that this line contains the condition number , lowest, highest, Eigenvalues of the correlation matrix of the variances of the final parameters.
 // NONMEM Users Guide: Introduction to NONMEM 7.4.1.

--- a/parsers/nmparser/read_grd.go
+++ b/parsers/nmparser/read_grd.go
@@ -39,7 +39,7 @@ func ParseGrdLines(lines []string) ExtData {
 	}
 }
 
-//ParseGrdData returns the ExtData in the structure of final parameter estimates.
+// ParseGrdData returns the ExtData in the structure of final parameter estimates.
 func ParseGrdData(ed ExtData) ([]ParametersData, ParameterNames) {
 	var allParametersData []ParametersData
 	var thetas []string

--- a/runner/consts.go
+++ b/runner/consts.go
@@ -82,7 +82,7 @@ func EstOutputFileCleanLevels(r string) map[string]int {
 	return EstOutputFiles
 }
 
-//CleanFilesByRun sets clean levels for files by run.
+// CleanFilesByRun sets clean levels for files by run.
 func CleanFilesByRun(r string) map[string]int {
 	var EstOutputFiles = make(map[string]int)
 	// fileExtLvls are based on 1 = lowest priority -> n = highest priority

--- a/runner/estimate_model.go
+++ b/runner/estimate_model.go
@@ -17,7 +17,8 @@ import (
 // EstimateModel prepares, runs and cleans up a model estimation run
 // modelPath is the relative path of the model from where Estimate model is called from
 // cacheDir is the location of the cache dir, relative to the baseDir,
-//		for nonmem executable for version 7.4 for use in precompilation
+// for nonmem executable for version 7.4 for use in precompilation
+//
 // exeNameInCache is the name of the nonmem executable in the cache dir.
 func EstimateModel(
 	fs afero.Fs,

--- a/runner/estimate_model_test.go
+++ b/runner/estimate_model_test.go
@@ -40,7 +40,7 @@ func TestCustomEstimateModel(tt *testing.T) {
 	})
 }
 
-//Should just get back the provided output dir.
+// Should just get back the provided output dir.
 func TestLogiclessTemplateForEstimateModel(tt *testing.T) {
 	testId := "UNIT-RUN-005"
 	tt.Run(utils.AddTestId("", testId), func(tt *testing.T) {

--- a/runner/prepare_to_execute.go
+++ b/runner/prepare_to_execute.go
@@ -6,7 +6,7 @@ import (
 	parser "github.com/metrumresearchgroup/bbi/parsers/nmparser"
 )
 
-//PrepareForExecution parses and prepares strings from a file for execution in a different context
+// PrepareForExecution parses and prepares strings from a file for execution in a different context
 // for example, replacing the $DATA path.
 func PrepareForExecution(s []string) []string {
 	for i, line := range s {

--- a/runner/structs.go
+++ b/runner/structs.go
@@ -24,7 +24,7 @@ type ReturnStatus struct {
 	Error  error  `json:"error,omitempty"`
 }
 
-//NextDirSuggestion provides a struct for the recommended next
+// NextDirSuggestion provides a struct for the recommended next
 // directory name, and whether there should be a project reorganization
 // based on directory modifications, and whether this will be the first dir in the sequence.
 type NextDirSuggestion struct {

--- a/utils/expand_sequence.go
+++ b/utils/expand_sequence.go
@@ -8,7 +8,8 @@ import (
 )
 
 // ExpandNameSequence takes a full name pattern with a sequence and returns all values
-//  run[001:004].mod --> run001.mod run002.mod run003.mod run004.mod
+//
+//	run[001:004].mod --> run001.mod run002.mod run003.mod run004.mod
 func ExpandNameSequence(fnp string) ([]string, error) {
 	var output []string
 	r := regexp.MustCompile(`(.*)?\[(.*)](.*)?`)

--- a/utils/io.go
+++ b/utils/io.go
@@ -11,9 +11,8 @@ import (
 	"github.com/spf13/afero"
 )
 
-//ReadParamsAndOutputFromExt returns the lines associated
+// ReadParamsAndOutputFromExt returns the lines associated
 // with either parameter table outputs or output lines (-100xxx lines).
-//
 func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 	inFile, err := os.Open(path)
 	if err != nil {
@@ -61,7 +60,7 @@ func ReadParamsAndOutputFromExt(path string) ([]string, error) {
 	return lines, nil
 }
 
-//ReadLines reads lines for a file at a given path.
+// ReadLines reads lines for a file at a given path.
 func ReadLines(path string) ([]string, error) {
 	inFile, err := os.Open(path)
 	if err != nil {
@@ -78,7 +77,7 @@ func ReadLines(path string) ([]string, error) {
 	return lines, nil
 }
 
-//ReadLinesFS reads lines for a file at a given path.
+// ReadLinesFS reads lines for a file at a given path.
 func ReadLinesFS(fs afero.Fs, path string) ([]string, error) {
 	inFile, err := fs.Open(path)
 	if err != nil {
@@ -95,7 +94,7 @@ func ReadLinesFS(fs afero.Fs, path string) ([]string, error) {
 	return lines, nil
 }
 
-//WriteLines writes lines to a file at a given path given a filesystem.
+// WriteLines writes lines to a file at a given path given a filesystem.
 func WriteLines(lines []string, path string) error {
 	file, err := os.Create(path)
 	if err != nil {
@@ -111,7 +110,7 @@ func WriteLines(lines []string, path string) error {
 	return w.Flush()
 }
 
-//WriteLinesFS writes lines to a file at a given path given a filesystem.
+// WriteLinesFS writes lines to a file at a given path given a filesystem.
 func WriteLinesFS(fs afero.Fs, lines []string, path string) error {
 	file, err := fs.Create(path)
 	if err != nil {


### PR DESCRIPTION
 * The incoming valtools branch triggers the lint workflow to fail for reasons related to a dot import.

   https://github.com/metrumresearchgroup/bbi/actions/runs/10370260543/job/28707761437

   I don't understand why the lint workflow is happy on main but not after that series, but, either way, it's a good idea to use a qualified import, so I just switched to that.

 * After that, the lint workflow fails with an obscure error I don't understand:

   https://github.com/metrumresearchgroup/bbi/actions/runs/10370823460/job/28709603032
  
   Resolve that by upgrading the lint workflow the latest golangci-lint.  To do that, we need to 1) update the golangci configuration and 2) reformat doc comments in the code base with a newer Go.

