### PR TITLE
ci: update golangci-lint to latest version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59
+          version: v1.60


### PR DESCRIPTION
The latest lint job for main failed with many errors [[1]] despite the same tree passing before the PR was merged [[2]].  The lint job pulls in the latest stable Go, so it's likely that the failure is due to some interaction between golangci-lint and the Go 1.23 update.

Update golangci-lint to its latest version to resolve the failure.

[1]: https://github.com/metrumresearchgroup/bbi/actions/runs/10395527571/job/28787806080
[2]: https://github.com/metrumresearchgroup/bbi/actions/runs/10379044354/job/28736486108