### PR TITLE
clean: fix handling of files from *_copied.json

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -115,7 +115,10 @@ func clean(cmd *cobra.Command, args []string) error {
 			}
 			// explicitly ignoring errors here, as this is not critical
 			// and it's more important to try than to succeed
-			_ = AppFs.RemoveAll(f)
+			err = AppFs.RemoveAll(f)
+			if err != nil {
+				log.Printf("failed to remove directory %s: %v", f, err)
+			}
 		}
 	}
 	if !dirsOnly {
@@ -125,7 +128,10 @@ func clean(cmd *cobra.Command, args []string) error {
 			}
 			// explicitly ignoring errors here, as this is not critical
 			// and it's more important to try than to succeed
-			_ = AppFs.Remove(f)
+			err = AppFs.Remove(f)
+			if err != nil {
+				log.Printf("failed to remove file %s: %v", f, err)
+			}
 		}
 	}
 

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -110,16 +110,22 @@ func clean(cmd *cobra.Command, args []string) error {
 
 	if !filesOnly {
 		for _, f := range matchedFolders {
+			if !filepath.IsAbs(f) {
+				f = filepath.Join(dir, f)
+			}
 			// explicitly ignoring errors here, as this is not critical
 			// and it's more important to try than to succeed
-			_ = AppFs.RemoveAll(filepath.Join(dir, f))
+			_ = AppFs.RemoveAll(f)
 		}
 	}
 	if !dirsOnly {
 		for _, f := range matchedFiles {
+			if !filepath.IsAbs(f) {
+				f = filepath.Join(dir, f)
+			}
 			// explicitly ignoring errors here, as this is not critical
 			// and it's more important to try than to succeed
-			_ = AppFs.Remove(filepath.Join(dir, f))
+			_ = AppFs.Remove(f)
 		}
 	}
 

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -647,8 +647,6 @@ func extrapolateCopyFilesFromExtensions(filename string, level int) []string {
 	extensions[2] = []string{
 		".clt",
 		".coi",
-		".clt",
-		".coi",
 		".cpu",
 		".shm",
 		".phi",

--- a/integration/nmless/bbi_clean_test.go
+++ b/integration/nmless/bbi_clean_test.go
@@ -230,7 +230,7 @@ func TestCleanCopiedRuns(tt *testing.T) {
 	writeCopied(t, filepath.Join(dir, "run10"),
 		[]runner.TargetedFile{
 			{
-				File: "run10.baz",
+				File: filepath.Join(dir, "run10.baz"),
 			},
 		},
 	)

--- a/runner/consts.go
+++ b/runner/consts.go
@@ -104,8 +104,6 @@ func EstOutputFilesByRun(r string) map[string]int {
 	fileExtsLvl2 := []string{
 		".clt",
 		".coi",
-		".clt",
-		".coi",
 		".cpu",
 		".shm",
 		".phi",


### PR DESCRIPTION
This PR fixes an issue I noticed when working on the `clean` examples for gh-329.

---

- [x] wait for merge of base (gh-330)