### PR TITLE
Update goreleaser configuration

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,5 +64,6 @@ jobs:
           args: release --clean
           workdir: cmd/bbi
         env:
+          VERSION: ${{ github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_GORELEASER_BREWS_TOKEN: ${{ secrets.GH_GORELEASER_BREWS_TOKEN }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,3 +65,4 @@ jobs:
           workdir: cmd/bbi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_GORELEASER_BREWS_TOKEN: ${{ secrets.GH_GORELEASER_BREWS_TOKEN }}

--- a/cmd/bbi/goreleaser.yml
+++ b/cmd/bbi/goreleaser.yml
@@ -33,6 +33,7 @@ release:
     name: bbi
     #Turning on auto marking of non standard releases as "pre" releases
   prerelease: auto
+  draft: true
 
 archives:
   -

--- a/cmd/bbi/goreleaser.yml
+++ b/cmd/bbi/goreleaser.yml
@@ -1,24 +1,16 @@
 # goreleaser.yml
 # Build customization
+version: 2
 project_name: bbi
-
-build:
-  binary: bbi
-  goos:
-    - windows
-    - darwin
-    - linux
-  goarch:
-    - amd64
 
 # goreleaser.yml
 brews:
   # Repository to push the tap to.
-  -
-    tap:
-      owner: metrumresearchgroup 
-      name: homebrew-tap 
-
+  - repository:
+      owner: metrumresearchgroup
+      name: homebrew-tap
+      branch: master
+      token: "{{ .Env.GH_GORELEASER_BREWS_TOKEN }}"
 
 builds:
   -

--- a/cmd/bbi/goreleaser.yml
+++ b/cmd/bbi/goreleaser.yml
@@ -42,7 +42,4 @@ archives:
     wrap_in_directory: true
     format: tar.gz
 changelog:
-  filters:
-    exclude:
-      - '^ci:'
-      - '^docs:'
+  disable: true


### PR DESCRIPTION
The goreleaser action (added in gh-323) requires version 2 of the config format.