### PR TITLE
treewide: drop inappropriate executable bits

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -44,7 +44,7 @@ func initializer(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Write the byte array to file
-	if err = afero.WriteFile(fs, "./bbi.yaml", yamlString, 0755); err != nil {
+	if err = afero.WriteFile(fs, "./bbi.yaml", yamlString, 0644); err != nil {
 		return fmt.Errorf("write bbi.yaml: %w", err)
 	}
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -272,7 +272,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 		// Write to File in original path indicating what all was copied
 		copiedJSON, _ := json.MarshalIndent(copied, "", "    ")
 
-		if err = afero.WriteFile(fs, path.Join(l.Nonmem.OriginalPath, l.Nonmem.FileName+"_copied.json"), copiedJSON, 0750); err != nil {
+		if err = afero.WriteFile(fs, path.Join(l.Nonmem.OriginalPath, l.Nonmem.FileName+"_copied.json"), copiedJSON, 0640); err != nil {
 			channels.Errors <- turnstile.ConcurrentError{
 				RunIdentifier: l.Nonmem.FileName,
 				Notes:         "could not write _copied.json file",
@@ -475,7 +475,7 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 		return newConcurrentError(model.Model, "Running the programmatic shell script caused an error", err)
 	}
 
-	if err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0750); err != nil {
+	if err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0640); err != nil {
 		return turnstile.ConcurrentError{Error: err, Notes: "unable to write model to output directory", RunIdentifier: model.FileName}
 	}
 
@@ -534,7 +534,7 @@ func writeNonmemConfig(model *NonMemModel) error {
 		return err
 	}
 
-	return afero.WriteFile(afero.NewOsFs(), path.Join(model.OutputDir, "bbi_config.json"), outBytes, 0750)
+	return afero.WriteFile(afero.NewOsFs(), path.Join(model.OutputDir, "bbi_config.json"), outBytes, 0640)
 }
 
 func HashFileOnChannel(ch chan string, file string, identifier string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,7 +154,7 @@ func logSetup(config configlib.Config) {
 		var outfile afero.File
 
 		if ok, _ := afero.Exists(fs, logfile); ok {
-			of, err := fs.OpenFile(logfile, os.O_APPEND|os.O_WRONLY, 0755)
+			of, err := fs.OpenFile(logfile, os.O_APPEND|os.O_WRONLY, 0644)
 
 			if err != nil {
 				log.Fatalf("Unable to open file at %s. Error is %s", logfile, err)

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -324,7 +324,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 		}
 	}
 
-	err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0750)
+	err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0640)
 
 	if err != nil {
 		return newConcurrentError(model.Model, "Having issues writing hte output file from command execution", err)

--- a/configlib/config.go
+++ b/configlib/config.go
@@ -82,7 +82,7 @@ func (c Config) RenderYamlToFile(path string) error {
 
 	targetFile := filepath.Join(path, "bbi.yaml")
 
-	err = afero.WriteFile(fs, targetFile, yamlBytes, 0755)
+	err = afero.WriteFile(fs, targetFile, yamlBytes, 0644)
 
 	if err != nil {
 		log.Error("An error occurred trying to write the serialized config yaml to file")

--- a/integration/nonmem/data_test.go
+++ b/integration/nonmem/data_test.go
@@ -75,7 +75,7 @@ func TestHasInvalidDataPath(tt *testing.T) {
 			adjusted := strings.Join(lines, "\n")
 			ab := []byte(adjusted)
 
-			err := os.WriteFile(filepath.Join(scenario.Workpath, m.filename), ab, 0755)
+			err := os.WriteFile(filepath.Join(scenario.Workpath, m.filename), ab, 0644)
 
 			if err != nil {
 				t.Log("Had a problem writing the file")


### PR DESCRIPTION
Adjust various spots that set the executable bit on files that cannot be executed (e.g., bbi.yaml and {model}.out files).

Close #181.