### PR TITLE
cmd: improve error reporting

### DIFF
--- a/cmd/local.go
+++ b/cmd/local.go
@@ -151,7 +151,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 		channels.Errors <- turnstile.ConcurrentError{
 			RunIdentifier: l.Nonmem.Model,
 			Error:         err,
-			Notes:         "An error occurred during the creation of the executable script for this model",
+			Notes:         "an error occurred during the creation of the executable script for this model",
 		}
 
 		return
@@ -474,7 +474,7 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         "Running the programmatic shell script caused an error",
+			Notes:         "running the programmatic shell script caused an error",
 			Error:         err,
 		}
 	}

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -151,7 +151,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 		channels.Errors <- turnstile.ConcurrentError{
 			RunIdentifier: l.Nonmem.Model,
 			Error:         err,
-			Notes:         "an error occurred during the creation of the executable script for this model",
+			Notes:         "failed to generate executable script",
 		}
 
 		return
@@ -163,7 +163,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 	if err = afero.WriteFile(fs, path.Join(l.Nonmem.OutputDir, l.Nonmem.FileName+".sh"), scriptContents, 0750); err != nil {
 		channels.Errors <- turnstile.ConcurrentError{
 			RunIdentifier: l.Nonmem.FileName,
-			Notes:         "writing the .sh file",
+			Notes:         "failed to write .sh file",
 			Error:         err,
 		}
 	}
@@ -172,7 +172,7 @@ func (l LocalModel) Prepare(channels *turnstile.ChannelMap) {
 		if err = writeParaFile(l.Nonmem); err != nil {
 			channels.Errors <- turnstile.ConcurrentError{
 				RunIdentifier: l.Nonmem.FileName,
-				Notes:         "writing to the parafile",
+				Notes:         "failed to write parafile",
 				Error:         err,
 			}
 			//			log.Fatalf("%s Configuration requires parallel operation, but generation or writing of the parafile has failed: %s", l.Nonmem.LogIdentifier(), err)
@@ -275,7 +275,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 		if err = afero.WriteFile(fs, path.Join(l.Nonmem.OriginalPath, l.Nonmem.FileName+"_copied.json"), copiedJSON, 0640); err != nil {
 			channels.Errors <- turnstile.ConcurrentError{
 				RunIdentifier: l.Nonmem.FileName,
-				Notes:         "could not write _copied.json file",
+				Notes:         "failed to write _copied.json file",
 				Error:         err,
 			}
 		}
@@ -305,7 +305,7 @@ func (l LocalModel) Cleanup(channels *turnstile.ChannelMap) {
 	if err = createNewGitIgnoreFile(l.Nonmem); err != nil {
 		channels.Errors <- turnstile.ConcurrentError{
 			RunIdentifier: l.Nonmem.FileName,
-			Notes:         "failed writing .gitignore file ",
+			Notes:         "failed to write .gitignore file",
 			Error:         err,
 		}
 	}
@@ -474,13 +474,17 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         "running the programmatic shell script caused an error",
+			Notes:         "error running shell script",
 			Error:         err,
 		}
 	}
 
 	if err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0640); err != nil {
-		return turnstile.ConcurrentError{Error: err, Notes: "unable to write model to output directory", RunIdentifier: model.FileName}
+		return turnstile.ConcurrentError{
+			RunIdentifier: model.FileName,
+			Notes:         "failed to write model output",
+			Error:         err,
+		}
 	}
 
 	return turnstile.ConcurrentError{}

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -472,7 +472,11 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 			log.Errorf("%s output details were: %s", model.LogIdentifier(), string(output))
 		}
 
-		return newConcurrentError(model.Model, "Running the programmatic shell script caused an error", err)
+		return turnstile.ConcurrentError{
+			RunIdentifier: model.Model,
+			Notes:         "Running the programmatic shell script caused an error",
+			Error:         err,
+		}
 	}
 
 	if err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0640); err != nil {

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -466,10 +466,7 @@ func executeLocalJob(model *NonMemModel) turnstile.ConcurrentError {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
 			code := exitError.ExitCode()
-			details := exitError.String()
-
-			log.Errorf("%s Exit code was %d, details were %s", model.LogIdentifier(), code, details)
-			log.Errorf("%s output details were: %s", model.LogIdentifier(), string(output))
+			log.Errorf("%s exit code: %d, output:\n%s", model.LogIdentifier(), code, string(output))
 		}
 
 		return turnstile.ConcurrentError{

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -696,7 +696,7 @@ func postWorkNotice(m *turnstile.Manager, t time.Time) {
 		log.Errorf("%d errors were experienced during the run", m.Errors)
 
 		for _, v := range m.ErrorList {
-			log.Errorf("Errors were experienced while running model %s. Details are %s", v.RunIdentifier, v.Notes)
+			log.Errorf("Error running model %s: %s\n\n%v", v.RunIdentifier, v.Notes, v.Error)
 		}
 	}
 

--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -323,7 +323,7 @@ func generateScript(fileTemplate string, l *NonMemModel) ([]byte, error) {
 	t, err := template.New("file").Parse(fileTemplate)
 	buf := new(bytes.Buffer)
 	if err != nil {
-		return []byte{}, errors.New("There was an error processing the provided script template")
+		return []byte{}, fmt.Errorf("parsing script template failed: %w", err)
 	}
 
 	type content struct {
@@ -344,7 +344,7 @@ func generateScript(fileTemplate string, l *NonMemModel) ([]byte, error) {
 	err = t.Execute(buf, cont)
 
 	if err != nil {
-		return []byte{}, errors.New("An error occured during the execution of the provided script template")
+		return []byte{}, fmt.Errorf("generating script template failed: %w", err)
 	}
 
 	if viper.GetBool("debug") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -177,7 +177,7 @@ func logSetup(config configlib.Config) {
 // RecordConcurrentError handles the processing of cancellation messages as well placing concurrent errors onto the stack.
 func RecordConcurrentError(model string, notes string, err error, channels *turnstile.ChannelMap, cancel chan bool, executor PostWorkExecutor) {
 	cancel <- true
-	channels.Errors <- newConcurrentError(model, notes, err)
+	channels.Errors <- turnstile.ConcurrentError{RunIdentifier: model, Notes: notes, Error: err}
 
 	PostWorkExecution(executor, false, err)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/metrumresearchgroup/turnstile"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -339,7 +338,7 @@ func onlyBbiVariables(provided []string) []string {
 
 // runModelCommand runs command, writing the combined standard output and
 // standard error to {model.OutputDir}/{model.Model}.out.  command should be
-// primed to run, but Stdout and Stderr must not be set.
+// primed to run; existing values for Stdout and Stderr are ignored.
 //
 // ignoreError is a function called if running the command fails.  It takes the
 // error and combined standard output and standard error as arguments.  A return
@@ -349,29 +348,52 @@ func runModelCommand(
 	model *NonMemModel, command *exec.Cmd, ignoreError func(error, string) bool,
 ) turnstile.ConcurrentError {
 
-	output, err := command.CombinedOutput()
-	if err != nil && !ignoreError(err, string(output)) {
-		log.Debug(err)
-
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			code := exitError.ExitCode()
-			log.Errorf("%s exit code: %d, output:\n%s", model.LogIdentifier(), code, string(output))
+	outfile := filepath.Join(model.OutputDir, model.Model+".out")
+	outfh, err := os.OpenFile(outfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o640)
+	if err != nil {
+		if errClose := outfh.Close(); errClose != nil {
+			log.Errorf("error closing output file: %v", errClose)
 		}
 
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         fmt.Sprintf("error running %q", command.String()),
+			Notes:         "unable to create model output file",
 			Error:         err,
 		}
 	}
 
-	fs := afero.NewOsFs()
-	if err = afero.WriteFile(fs, filepath.Join(model.OutputDir, model.Model+".out"), output, 0640); err != nil {
-		return turnstile.ConcurrentError{
-			RunIdentifier: model.Model,
-			Notes:         "failed to write model output",
-			Error:         err,
+	command.Stdout = outfh
+	command.Stderr = outfh
+
+	if err = command.Run(); err != nil {
+		if errClose := outfh.Close(); errClose != nil {
+			log.Errorf("error closing output file: %v", errClose)
+		}
+
+		ignore := false
+		output, errRead := os.ReadFile(outfile)
+		if errRead == nil {
+			ignore = ignoreError(err, string(output))
+		} else {
+			log.Errorf("error reading output file: %v", errRead)
+		}
+
+		if !ignore {
+			log.Debug(err)
+
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				code := exitError.ExitCode()
+				log.Errorf("%s exit code: %d, output:\n%s",
+					model.LogIdentifier(), code, string(output))
+			}
+
+			return turnstile.ConcurrentError{
+				RunIdentifier: model.Model,
+				Notes: fmt.Sprintf("error running %q; command output written to %q",
+					command.String(), outfile),
+				Error: err,
+			}
 		}
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -53,6 +53,16 @@ func TestRunModelCommandError(tt *testing.T) {
 
 	cerr := runModelCommand(mod, cmd, never)
 	t.A.Error(cerr.Error)
+	t.A.Contains(cerr.Notes, mod.Model+".out")
+
+	outfile := filepath.Join(mod.OutputDir, mod.Model+".out")
+	t.R.FileExists(outfile)
+	bs, err := os.ReadFile(outfile)
+	t.R.NoError(err)
+	output = string(bs)
+
+	t.A.Contains(output, "stdout")
+	t.A.Contains(output, "stderr")
 }
 
 func TestRunModelCommandIgnoreError(tt *testing.T) {

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/metrumresearchgroup/turnstile"
+	"github.com/metrumresearchgroup/wrapt"
+)
+
+func skipIfNoSh(t *wrapt.T) {
+	t.Helper()
+	_, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skipf("skipped because sh is not available")
+	}
+}
+
+func never(_ error, _ string) bool {
+	return false
+}
+
+func TestRunModelCommand(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+
+	skipIfNoSh(t)
+
+	cmd := exec.Command("sh", "-c", "printf 'stdout\n'; printf >&2 'stderr\n'")
+	mod := &NonMemModel{Model: "foo.ctl", FileName: "foo", OutputDir: t.TempDir()}
+	cerr := runModelCommand(mod, cmd, never)
+	t.A.Equal(cerr, turnstile.ConcurrentError{})
+
+	outfile := filepath.Join(mod.OutputDir, mod.Model+".out")
+	t.R.FileExists(outfile)
+	bs, err := os.ReadFile(outfile)
+	t.R.NoError(err)
+	output = string(bs)
+
+	t.A.Contains(output, "stdout")
+	t.A.Contains(output, "stderr")
+}
+
+func TestRunModelCommandError(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+
+	skipIfNoSh(t)
+
+	cmd := exec.Command("sh", "-c", "printf 'stdout\n'; printf >&2 'stderr\n'; exit 1")
+	mod := &NonMemModel{Model: "foo.ctl", FileName: "foo", OutputDir: t.TempDir()}
+
+	cerr := runModelCommand(mod, cmd, never)
+	t.A.Error(cerr.Error)
+}
+
+func TestRunModelCommandIgnoreError(tt *testing.T) {
+	t := wrapt.WrapT(tt)
+
+	skipIfNoSh(t)
+
+	cmd := exec.Command("sh", "-c", "printf 'stdout\n'; printf >&2 'IGNORE\n'; exit 1")
+	mod := &NonMemModel{Model: "foo.ctl", FileName: "foo", OutputDir: t.TempDir()}
+
+	ign := func(_ error, output string) bool {
+		return strings.Contains(output, "IGNORE")
+	}
+
+	cerr := runModelCommand(mod, cmd, ign)
+	t.A.Equal(cerr, turnstile.ConcurrentError{})
+
+	outfile := filepath.Join(mod.OutputDir, mod.Model+".out")
+	t.R.FileExists(outfile)
+	bs, err := os.ReadFile(outfile)
+	t.R.NoError(err)
+	output = string(bs)
+
+	t.A.Contains(output, "stdout")
+	t.A.Contains(output, "IGNORE")
+}

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path"
@@ -317,6 +318,11 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	if err != nil {
 		//Let's look to see if it's just because of the typical "No queues present" error
 		if !strings.Contains(string(output), "job is not allowed to run in any queue") {
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
+				code := exitError.ExitCode()
+				log.Errorf("%s exit code: %d, output:\n%s", model.LogIdentifier(), code, string(output))
+			}
 			//If the error doesn't appear to be the above error, we'll generate the concurrent error and move along
 			return turnstile.ConcurrentError{
 				RunIdentifier: model.Model,

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -327,7 +327,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	err = afero.WriteFile(fs, path.Join(model.OutputDir, model.Model+".out"), output, 0640)
 
 	if err != nil {
-		return newConcurrentError(model.Model, "Having issues writing hte output file from command execution", err)
+		return newConcurrentError(model.Model, "Having issues writing the output file from command execution", err)
 	}
 
 	return turnstile.ConcurrentError{}

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"os/exec"
 	"path"
@@ -364,7 +363,7 @@ func generateBbiScript(fileTemplate string, l NonMemModel) ([]byte, error) {
 	t, err := template.New("file").Parse(fileTemplate)
 	buf := new(bytes.Buffer)
 	if err != nil {
-		return []byte{}, errors.New("There was an error processing the provided script template")
+		return []byte{}, fmt.Errorf("parsing bbi script template failed: %w", err)
 	}
 
 	filename := l.Model
@@ -411,7 +410,7 @@ func generateBbiScript(fileTemplate string, l NonMemModel) ([]byte, error) {
 	})
 
 	if err != nil {
-		return []byte{}, errors.New("An error occured during the execution of the provided script template")
+		return []byte{}, fmt.Errorf("failed to generate bbi script: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -322,7 +322,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 			//If the error doesn't appear to be the above error, we'll generate the concurrent error and move along
 			return turnstile.ConcurrentError{
 				RunIdentifier: model.Model,
-				Notes:         "running the programmatic shell script caused an error",
+				Notes:         "error running submission script",
 				Error:         err,
 			}
 		}
@@ -333,7 +333,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	if err != nil {
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         "having issues writing the output file from command execution",
+			Notes:         "failed to write model output",
 			Error:         err,
 		}
 	}

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -262,7 +262,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	if err != nil {
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.FileName,
-			Notes:         "Failed to template out name for job submission",
+			Notes:         "failed to template out name for job submission",
 			Error:         err,
 		}
 	}
@@ -295,7 +295,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	if err != nil {
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         "Could not locate qsub binary in path",
+			Notes:         "could not locate qsub binary in path",
 			Error:         err,
 		}
 	}
@@ -322,7 +322,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 			//If the error doesn't appear to be the above error, we'll generate the concurrent error and move along
 			return turnstile.ConcurrentError{
 				RunIdentifier: model.Model,
-				Notes:         "Running the programmatic shell script caused an error",
+				Notes:         "running the programmatic shell script caused an error",
 				Error:         err,
 			}
 		}
@@ -333,7 +333,7 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	if err != nil {
 		return turnstile.ConcurrentError{
 			RunIdentifier: model.Model,
-			Notes:         "Having issues writing the output file from command execution",
+			Notes:         "having issues writing the output file from command execution",
 			Error:         err,
 		}
 	}

--- a/cmd/sge.go
+++ b/cmd/sge.go
@@ -271,6 +271,13 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 
 	//Find Qsub
 	binary, err := exec.LookPath("qsub")
+	if err != nil {
+		return turnstile.ConcurrentError{
+			RunIdentifier: model.Model,
+			Notes:         "could not locate qsub binary in path",
+			Error:         err,
+		}
+	}
 
 	qsubArguments := []string{}
 
@@ -291,14 +298,6 @@ func executeSGEJob(model *NonMemModel) turnstile.ConcurrentError {
 	}
 
 	qsubArguments = append(qsubArguments, filepath.Join(model.OutputDir, scriptName))
-
-	if err != nil {
-		return turnstile.ConcurrentError{
-			RunIdentifier: model.Model,
-			Notes:         "could not locate qsub binary in path",
-			Error:         err,
-		}
-	}
 
 	command := exec.Command(binary, qsubArguments...)
 


### PR DESCRIPTION
This series focuses on improving errors reported by `bbi nonmem run {local,sge}`.

The two main improvements make information more available for troubleshooting:

 * the underlying error is now included when reporting turnstile.ConcurrentErrors
 * even when there is an error, the standard output and standard error for the local and SGE command invocations are written to `{model}.out`

---

- [x] wait for merge of base (gh-335)