### PR TITLE
nonmem: fix relay of --licfile option to nmfe

### DIFF
--- a/cmd/nonmem.go
+++ b/cmd/nonmem.go
@@ -211,7 +211,7 @@ func NewNonmemCmd() *cobra.Command {
 	const nmfeGroup string = "nmfe_options"
 	const licFileIdentifier string = "licfile"
 	cmd.PersistentFlags().String(licFileIdentifier, "", "RAW NMFE OPTION - NONMEM license file to use")
-	errpanic(viper.BindPFlag(nmfeGroup+"."+licFileIdentifier, cmd.PersistentFlags().Lookup(licFileIdentifier)))
+	errpanic(viper.BindPFlag(nmfeGroup+".license_file", cmd.PersistentFlags().Lookup(licFileIdentifier)))
 
 	const prSameIdentifier string = "prsame"
 	cmd.PersistentFlags().Bool(prSameIdentifier, false, "RAW NMFE OPTION - tell NONMEM to skip the PREDPP compilation step")


### PR DESCRIPTION
Specifying --licfile does not relay the -licfile to the nmfe call in the {model}.sh script because there is a mismatch between the command-line option name (licfile) and the configuration (license_file).

Adjust the viper lookup to use the correct identifier.

Fixes #337