### PR TITLE
Prepare 3.4.0 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,30 @@
 
+# bbi 3.4.0
+
+## New features and changes
+
+* The new `bbi nonmem run slurm` subcommand provides support for Slurm
+  execution.  (#338)
+
+* `bbi nonmem run` now always writes the underlying command's output
+  to `{model}.out` as opposed to doing so only when the command
+  succeeds.  (#336)
+
+* `bbi nonmem run` now logs more details about failures.  (#336)
+
+* The executable bit is no longer set when writing files that are not
+  intended to be executed, including `bbi.yaml`.  (#335)
+
+## Bug fixes
+
+* `bbi nonmem run` did not relay its `--licfile` command-line argument
+  to the underlying `nmfe` call.  (#339)
+
+* Some spots that parse floats from NONMEM output files did not map
+  `NaN` values to the `-999999999` placeholder, causing `bbi nonmem
+  summary --json` to abort.  (#334)
+
+
 # bbi 3.3.1
 
 Documentation is now available at

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ command line interface for executing and managing models and projects. The nomen
 
 For Example:
 
-`bbi nonmem run sge path/to/file.mod`
+`bbi nonmem run local path/to/file.mod`
 
  * `nonmem` : The modeling software we should be targeting for this run
- * `sge` : The mode of execution. For nonmem this can either be local or sge, with sge indicating submission of jobs to the grid
+ * `local` : The mode of execution. For nonmem this can either be `local`, `slurm` (grid submission via Slurm), or `sge` (grid submission via SGE)
  * `path/to/file.mod` : The location of the file to submit for execution. Can be relative or absolute. 
 
  #### Configuration
@@ -45,15 +45,15 @@ For Example:
  * In the executing user's home (`~`) directory
 
 
- #### Configuration and SGE
+ #### Configuration and grid submission
 
- You may notice that if you issue a job with nonmem targeting SGE that a `bbi.yaml` file is created for you automatically. This is because SGE execution wraps the `bbi` CLI into an executable for the grid to execute. This ensures the following:
+ You may notice that if you issue a job with nonmem targeting the grid (via the `sge` or `slurm` subcommand) that a `bbi.yaml` file is created for you automatically. This is because grid execution wraps the `bbi` CLI into an executable for the grid to execute. This ensures the following:
 
- * Execution via SGE is done **the exact same way** that local execution for nonmem occurs. 
+ * Execution on the grid is done **the exact same way** that local execution for nonmem occurs.
  * This includes cleanup, copy-up, and git operations
  * Also ensures a single execution path 
 
- To do this sanely, we make sure that the parameters provided on the initial SGE run are captured and stored with the model. This way, each subsequent `bbi` call made from the grid is made with the *exact same parameters*.
+ To do this sanely, we make sure that the parameters provided on the initial run are captured and stored with the model. This way, each subsequent `bbi` call made from the grid is made with the *exact same parameters*.
 
 ### Summary output
 


### PR DESCRIPTION
changeset: https://github.com/metrumresearchgroup/bbi/compare/b63ceabdeecb34f2b6f7cd761ccc7fc95fccee58...eb49f40525383e37f0f76725c0e09126f3bfe474

<details>
<summary>scores.json (SGE)</summary>

```
$ which sbatch
$ echo $?
1

$ cat internal/valtools/output/bbi_3.3.1-40-geb49f40/bbi_3.3.1-40-geb49f40.scores.json
{
  "testing": {
    "check": 1,
    "coverage": 0.8403502862916806
  },
  "documentation": {
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>

<details>
<summary>scores.json (Slurm)</summary>

```
$ which sbatch
/opt/slurm/bin/sbatch

$ cat internal/valtools/output/bbi_3.3.1-40-geb49f40/bbi_3.3.1-40-geb49f40.scores.json
{
  "testing": {
    "check": 1,
    "coverage": 0.8403502862916806
  },
  "documentation": {
    "has_website": 1,
    "has_news": 1
  },
  "maintenance": {
    "has_maintainer": 1,
    "news_current": 1
  },
  "transparency": {
    "has_source_control": 1,
    "has_bug_reports_url": 1
  }
}
```

</details>

<details>
<summary>note on overall coverage value</summary>

The overall coverage value is identical across the Slurm and SGE runs.   At first I saw that and thought I must have executed the tests on the wrong system.  But indeed each run has the same set of per-file coverage values, with the `cmd/sge.go` and `cmd/slurm.go` values flipped across runs.  Here's a diff of `internal/valtools/output/bbi_3.3.1-40-geb49f40/bbi_3.3.1-40-geb49f40.coverage.json` from both runs:

```diff
diff --git a/sge-cov.json b/slurm-cov.json
index 572fa3a..e50e418 100644
--- a/sge-cov.json
+++ b/slurm-cov.json
@@ -55,11 +55,11 @@
     },
     {
       "file": "cmd/sge.go",
-      "coverage": 90
+      "coverage": 70
     },
     {
       "file": "cmd/slurm.go",
-      "coverage": 70
+      "coverage": 90
     },
     {
       "file": "cmd/summary.go",
```

</details>
